### PR TITLE
Возможность давать объектам свои имена для сериализации в JSON

### DIFF
--- a/src/one/nio/serial/JsonName.java
+++ b/src/one/nio/serial/JsonName.java
@@ -1,0 +1,13 @@
+package one.nio.serial;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE,  ElementType.FIELD})
+public @interface JsonName {
+
+    String name();
+}

--- a/src/one/nio/serial/JsonName.java
+++ b/src/one/nio/serial/JsonName.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Odnoklassniki Ltd, Mail.Ru Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package one.nio.serial;
 
 import java.lang.annotation.ElementType;

--- a/src/one/nio/serial/JsonName.java
+++ b/src/one/nio/serial/JsonName.java
@@ -25,5 +25,5 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE,  ElementType.FIELD})
 public @interface JsonName {
 
-    String name();
+    String value();
 }

--- a/src/one/nio/serial/gen/DelegateGenerator.java
+++ b/src/one/nio/serial/gen/DelegateGenerator.java
@@ -284,7 +284,7 @@ public class DelegateGenerator extends BytecodeGenerator {
             JsonName jsonName = ownField.getAnnotation(JsonName.class);
 
             if (jsonName != null) {
-                name = jsonName.name();
+                name = jsonName.value();
             }
 
             String fieldName = "\"" + name + "\":";

--- a/src/one/nio/serial/gen/DelegateGenerator.java
+++ b/src/one/nio/serial/gen/DelegateGenerator.java
@@ -17,9 +17,7 @@
 package one.nio.serial.gen;
 
 import one.nio.gen.BytecodeGenerator;
-import one.nio.serial.Default;
-import one.nio.serial.FieldDescriptor;
-import one.nio.serial.Repository;
+import one.nio.serial.*;
 import one.nio.util.JavaInternals;
 
 import org.objectweb.asm.ClassVisitor;
@@ -165,7 +163,7 @@ public class DelegateGenerator extends BytecodeGenerator {
         mv.visitVarInsn(ASTORE, 2);
         mv.visitMethodInsn(INVOKEVIRTUAL, "one/nio/serial/DataStream", "register", "(Ljava/lang/Object;)V");
 
-        ArrayList<Field> parents = new ArrayList<Field>(1);
+        ArrayList<Field> parents = new ArrayList<>(1);
         for (FieldDescriptor fd : fds) {
             Field ownField = fd.ownField();
             Field parentField = fd.parentField();
@@ -276,11 +274,20 @@ public class DelegateGenerator extends BytecodeGenerator {
 
         for (FieldDescriptor fd : fds) {
             Field ownField = fd.ownField();
+
             if (ownField == null) {
                 continue;
             }
 
-            String fieldName = "\"" + ownField.getName() + "\":";
+            String name = ownField.getName();
+
+            JsonName jsonName = ownField.getAnnotation(JsonName.class);
+
+            if (jsonName != null) {
+                name = jsonName.name();
+            }
+
+            String fieldName = "\"" + name + "\":";
             mv.visitLdcInsn(firstWritten ? ',' + fieldName : '{' + fieldName);
             mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/StringBuilder", "append", "(Ljava/lang/String;)Ljava/lang/StringBuilder;");
             firstWritten = true;
@@ -391,12 +398,6 @@ public class DelegateGenerator extends BytecodeGenerator {
             return;
         }
 
-        // Type widening
-        if (src.isAssignableFrom(dst)) {
-            mv.visitTypeInsn(CHECKCAST, Type.getInternalName(dst));
-            return;
-        }
-
         // Primitive -> Primitive
         if (src.isPrimitive() && dst.isPrimitive()) {
             FieldType srcType = FieldType.valueOf(src);
@@ -427,10 +428,16 @@ public class DelegateGenerator extends BytecodeGenerator {
             return;
         }
 
+        // Type widening
+        if (src.isAssignableFrom(dst)) {
+            mv.visitTypeInsn(CHECKCAST, Type.getInternalName(dst));
+            return;
+        }
+
         // Number -> Number
         if (src.getSuperclass() == Number.class && dst.getSuperclass() == Number.class) {
             for (Method m : dst.getMethods()) {
-                if (m.getParameterTypes().length == 0 && m.getReturnType() == dst &&
+                if (m.getParameterTypes().length == 1 && m.getReturnType() == dst &&
                         Modifier.isStatic(m.getModifiers()) && "valueOf".equals(m.getName())) {
                     Class param = m.getParameterTypes()[0];
                     if (param.isPrimitive() && param != boolean.class && param != char.class) {

--- a/test/one/nio/serial/JsonTest.java
+++ b/test/one/nio/serial/JsonTest.java
@@ -24,11 +24,23 @@ import java.util.HashMap;
 public class JsonTest implements Serializable {
 
     private long lng = Long.MIN_VALUE;
-    private Object map = new HashMap<String, String>() {{ put("someKey", "some \"Value\"" ); }};
+    private Object map = new HashMap<String, String>() {{
+        put("someKey", "some \"Value\"");
+    }};
 
     public static void main(String[] args) throws IOException {
         Object obj = Arrays.asList("abc", 1, 2.0, true, new JsonTest());
         System.out.println(Json.toJson(obj));
+
+        TestObject object = new TestObject();
+        object.name = "Maxim";
+        System.out.println(Json.toJson(object));
+    }
+
+    public static class TestObject implements Serializable {
+
+        @JsonName(name = "test_name")
+        public String name;
     }
 
 }


### PR DESCRIPTION
При использовании библиотеки наткнулся на небольшую проблему. Нельзя было задать обьектам свои имена. Теперь проблему решил добавлением аннотации, теперь не нужно делать названия переменных в виде - "error_text" и т.п. 