### PR TITLE
Support for HTTP request body

### DIFF
--- a/src/one/nio/http/HttpSession.java
+++ b/src/one/nio/http/HttpSession.java
@@ -80,7 +80,7 @@ public class HttpSession extends Session {
                 System.arraycopy(buffer, processed, fragment, 0, length);
             }
             fragmentLength = length;
-        } catch (HttpException e) {
+        } catch (IllegalArgumentException | HttpException e) {
             if (log.isDebugEnabled()) {
                 log.debug("Bad request", e);
             }

--- a/src/one/nio/http/Request.java
+++ b/src/one/nio/http/Request.java
@@ -62,7 +62,6 @@ public class Request {
     private static final byte[] HTTP10_HEADER = Utf8.toBytes(" HTTP/1.0\r\n");
     private static final byte[] HTTP11_HEADER = Utf8.toBytes(" HTTP/1.1\r\n");
     private static final int PROTOCOL_HEADER_LENGTH = 13;
-    private static final byte[] EMPTY_BODY = new byte[0];
 
     private int method;
     private String uri;
@@ -70,7 +69,7 @@ public class Request {
     private int params;
     private int headerCount;
     private String[] headers;
-    private byte[] body = EMPTY_BODY;
+    private byte[] body;
 
     public Request(int method, String uri, boolean http11) {
         this.method = method;

--- a/src/one/nio/http/Request.java
+++ b/src/one/nio/http/Request.java
@@ -62,6 +62,7 @@ public class Request {
     private static final byte[] HTTP10_HEADER = Utf8.toBytes(" HTTP/1.0\r\n");
     private static final byte[] HTTP11_HEADER = Utf8.toBytes(" HTTP/1.1\r\n");
     private static final int PROTOCOL_HEADER_LENGTH = 13;
+    private static final byte[] EMPTY_BODY = new byte[0];
 
     private int method;
     private String uri;
@@ -69,7 +70,7 @@ public class Request {
     private int params;
     private int headerCount;
     private String[] headers;
-    private byte[] body;
+    private byte[] body = EMPTY_BODY;
 
     public Request(int method, String uri, boolean http11) {
         this.method = method;

--- a/test/one/nio/http/HttpRequestBodyTest.java
+++ b/test/one/nio/http/HttpRequestBodyTest.java
@@ -122,7 +122,7 @@ public class HttpRequestBodyTest {
 
         @Path(ENDPOINT)
         public Response echoBody(Request request) throws IOException {
-            return Response.ok(request.getBody());
+            return Response.ok(request.getBody() == null ? Response.EMPTY : request.getBody());
         }
     }
 }

--- a/test/one/nio/http/HttpRequestBodyTest.java
+++ b/test/one/nio/http/HttpRequestBodyTest.java
@@ -1,0 +1,128 @@
+package one.nio.http;
+
+import one.nio.net.ConnectionString;
+import one.nio.server.ServerConfig;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for client and server support for HTTP request body
+ *
+ * @author Vadim Tsesko <mail@incubos.org>
+ */
+public class HttpRequestBodyTest {
+    private static final String URL = "http://0.0.0.0:8181";
+    private static final String ENDPOINT = "/echoBody";
+
+    private static HttpServer server;
+    private static HttpClient client;
+
+    @BeforeClass
+    public static void beforeAll() throws IOException {
+        server = new TestServer(ServerConfig.from(URL));
+        server.start();
+        client = new HttpClient(new ConnectionString(URL));
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        client.close();
+        server.stop();
+    }
+
+    @Test
+    public void maxPostBody() throws Exception {
+        final byte[] body = new byte[HttpSession.MAX_REQUEST_BODY_LENGTH];
+        ThreadLocalRandom.current().nextBytes(body);
+
+        final Response response = client.post(ENDPOINT, body);
+        assertEquals(200, response.getStatus());
+        assertArrayEquals(body, response.getBody());
+    }
+
+    @Test
+    public void tooBigPostBody() throws Exception {
+        final byte[] body = new byte[HttpSession.MAX_REQUEST_BODY_LENGTH + 1];
+        ThreadLocalRandom.current().nextBytes(body);
+
+        final Response response = client.post(ENDPOINT, body);
+        assertEquals(413, response.getStatus());
+    }
+
+    @Test
+    public void emptyPostBody() throws Exception {
+        final Response response = client.post(ENDPOINT);
+        assertEquals(200, response.getStatus());
+        assertEquals(0, response.getBody().length);
+    }
+
+    @Test
+    public void put() throws Exception {
+        final byte[] body = new byte[HttpSession.MAX_REQUEST_BODY_LENGTH];
+        ThreadLocalRandom.current().nextBytes(body);
+
+        final Response response = client.put(ENDPOINT, body);
+        assertEquals(200, response.getStatus());
+        assertArrayEquals(body, response.getBody());
+    }
+
+    @Test
+    public void tooBigPutBody() throws Exception {
+        final byte[] body = new byte[HttpSession.MAX_REQUEST_BODY_LENGTH + 1];
+        ThreadLocalRandom.current().nextBytes(body);
+
+        final Response response = client.put(ENDPOINT, body);
+        assertEquals(413, response.getStatus());
+    }
+
+    @Test
+    public void emptyPutBody() throws Exception {
+        final Response response = client.put(ENDPOINT);
+        assertEquals(200, response.getStatus());
+        assertEquals(0, response.getBody().length);
+    }
+
+    @Test
+    public void patch() throws Exception {
+        final byte[] body = new byte[HttpSession.MAX_REQUEST_BODY_LENGTH];
+        ThreadLocalRandom.current().nextBytes(body);
+
+        final Response response = client.patch(ENDPOINT, body);
+        assertEquals(200, response.getStatus());
+        assertArrayEquals(body, response.getBody());
+    }
+
+    @Test
+    public void tooBigPatchBody() throws Exception {
+        final byte[] body = new byte[HttpSession.MAX_REQUEST_BODY_LENGTH + 1];
+        ThreadLocalRandom.current().nextBytes(body);
+
+        final Response response = client.patch(ENDPOINT, body);
+        assertEquals(413, response.getStatus());
+    }
+
+    @Test
+    public void emptyPatchBody() throws Exception {
+        final Response response = client.patch(ENDPOINT);
+        assertEquals(200, response.getStatus());
+        assertEquals(0, response.getBody().length);
+    }
+
+    public static class TestServer extends HttpServer {
+        TestServer(ServerConfig config) throws IOException {
+            super(config);
+        }
+
+        @Path(ENDPOINT)
+        public Response echoBody(Request request) throws IOException {
+            return Response.ok(request.getBody());
+        }
+    }
+}


### PR DESCRIPTION
- Default request body limit is 64 KB
- Support for request payload in all HTTP methods
- Unit tests for `PUT`, `POST` and `PATCH` requests
- Respond `413 Request Entity Too Large` if request body is too large