### PR TITLE
Enhanced http response with native buffer support and completion listener

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.28.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/src/one/nio/http/HttpSession.java
+++ b/src/one/nio/http/HttpSession.java
@@ -263,25 +263,9 @@ public class HttpSession extends Session {
 
     protected void writeResponse(Response response, boolean includeBody) throws IOException {
         byte[] bytes = response.toBytes(includeBody);
-
-        if (response.getBodyNativeAddr() > 0) {
-            super.write(new ArrayAndNativeQueueItem(bytes, 0, bytes.length, response.getBodyNativeAddr(), response.getBodyLength(), 0) {
-                @Override
-                public void release(Exception problem) {
-                    if (response.getListener() != null) {
-                        response.getListener().onDone(written, totalCount, problem);
-                    }
-                }
-            });
-        } else {
-            super.write(new ArrayQueueItem(bytes, 0, bytes.length, 0) {
-                @Override
-                public void release(Exception problem) {
-                    if (response.getListener() != null) {
-                        response.getListener().onDone(written, count, problem);
-                    }
-                }
-            });
-        }
+        super.write(new ArrayAndNativeQueueItem(
+                bytes, bytes.length,
+                response.bodyNativeAddr, response.bodyNativeAddr > 0 ? response.bodyLength : 0,
+                response.listener));
     }
 }

--- a/src/one/nio/http/Request.java
+++ b/src/one/nio/http/Request.java
@@ -49,7 +49,7 @@ public class Request {
     public static final byte[] VERB_CONNECT = Utf8.toBytes("CONNECT ");
     public static final byte[] VERB_PATCH   = Utf8.toBytes("PATCH ");
 
-    static final byte[][] VERBS = {
+    protected static final byte[][] VERBS = {
             new byte[0],
             VERB_GET,
             VERB_POST,
@@ -62,17 +62,17 @@ public class Request {
             VERB_PATCH
     };
 
-    private static final byte[] HTTP10_HEADER = Utf8.toBytes(" HTTP/1.0\r\n");
-    private static final byte[] HTTP11_HEADER = Utf8.toBytes(" HTTP/1.1\r\n");
-    private static final int PROTOCOL_HEADER_LENGTH = 13;
+    protected static final byte[] HTTP10_HEADER = Utf8.toBytes(" HTTP/1.0\r\n");
+    protected static final byte[] HTTP11_HEADER = Utf8.toBytes(" HTTP/1.1\r\n");
+    protected static final int PROTOCOL_HEADER_LENGTH = 13;
 
-    private int method;
-    private String uri;
-    private boolean http11;
-    private int params; // -1 if no query parameters
-    private int headerCount;
-    private String[] headers;
-    private byte[] body;
+    protected int method;
+    protected String uri;
+    protected boolean http11;
+    protected int params; // -1 if no query parameters
+    protected int headerCount;
+    protected String[] headers;
+    protected byte[] body;
 
     public Request(int method, String uri, boolean http11) {
         this.method = method;

--- a/src/one/nio/http/ResponseListener.java
+++ b/src/one/nio/http/ResponseListener.java
@@ -2,5 +2,5 @@ package one.nio.http;
 
 @FunctionalInterface
 public interface ResponseListener {
-    void onDone(int bytesSent, int totalToSend, Exception problem);
+    void onDone(int bytesSent, int totalToSend, Throwable problem);
 }

--- a/src/one/nio/http/ResponseListener.java
+++ b/src/one/nio/http/ResponseListener.java
@@ -1,0 +1,6 @@
+package one.nio.http;
+
+@FunctionalInterface
+public interface ResponseListener {
+    void onDone(int bytesSent, int totalToSend, Exception problem);
+}

--- a/src/one/nio/net/Session.java
+++ b/src/one/nio/net/Session.java
@@ -321,6 +321,12 @@ public class Session implements Closeable {
             this.nativeCount = nativeLength;
             this.listener = listener;
             this.totalCount = arrayLength + nativeLength;
+            if (nativeAddr <= 0 & nativeLength > 0) {
+                throw new IllegalArgumentException("Specified non-zero native buffer length but missing native address.");
+            }
+            if (array == null & arrayLength > 0) {
+                throw new IllegalArgumentException("Specified non-zero array length but missing array reference.");
+            }
         }
 
         @Override

--- a/src/one/nio/rpc/RpcSession.java
+++ b/src/one/nio/rpc/RpcSession.java
@@ -203,10 +203,10 @@ public class RpcSession<S, M> extends Session {
             streamProxy.bytesRead = stream.getBytesRead();
             streamProxy.bytesWritten = stream.getBytesWritten();
         } catch (ClassNotFoundException e) {
-            close();
+            close(e);
             throw new IOException(e);
         } catch (Throwable e) {
-            close();
+            close(e);
             throw e;
         }
 

--- a/src/one/nio/server/CleanupThread.java
+++ b/src/one/nio/server/CleanupThread.java
@@ -21,8 +21,17 @@ import one.nio.os.BatchThread;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.util.concurrent.TimeoutException;
+
 public class CleanupThread extends BatchThread {
     private static final Log log = LogFactory.getLog(CleanupThread.class);
+
+    public static final TimeoutException TIMEOUT_EXCEPTION = new TimeoutException(){
+        @Override
+        public synchronized Throwable fillInStackTrace() {
+            return this;
+        }
+    };
 
     private volatile SelectorThread[] selectors;
     private volatile long keepAlive;
@@ -90,7 +99,7 @@ public class CleanupThread extends BatchThread {
                             } else {
                                 staleCount++;
                             }
-                            session.close();
+                            session.close(TIMEOUT_EXCEPTION);
                         }
                     }
                 }

--- a/test/one/nio/http/HttpServerTest.java
+++ b/test/one/nio/http/HttpServerTest.java
@@ -20,6 +20,7 @@ import one.nio.net.Socket;
 import one.nio.util.Utf8;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 public class HttpServerTest extends HttpServer {
 
@@ -30,6 +31,17 @@ public class HttpServerTest extends HttpServer {
     @Path("/simple")
     public Response handleSimple() {
         return Response.ok("Simple");
+    }
+
+    @Path("/native")
+    public Response nativeResponse() {
+        byte[] out = "<html><body><h1>Hi!</ht1></body></html>".getBytes();
+        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(out.length);
+        byteBuffer.put(out);
+        byteBuffer.flip();
+        Response response = new Response(Response.OK, byteBuffer, (bytesSent, totalToSend, problem) -> System.out.println("Response complete. bytesSent=" + bytesSent + " total: " + totalToSend + " err: " + problem));
+        response.addHeader("Content-Type: text/html; charset=utf-8");
+        return response;
     }
 
     @Path({"/multi1", "/multi2"})

--- a/test/one/nio/net/SessionTest.java
+++ b/test/one/nio/net/SessionTest.java
@@ -1,0 +1,146 @@
+package one.nio.net;
+
+import one.nio.http.ResponseListener;
+import one.nio.mem.DirectMemory;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+public class SessionTest {
+
+    Socket mockedSocket = Mockito.mock(Socket.class);
+    ResponseListener mockedListener = Mockito.mock(ResponseListener.class);
+    long nativeAddress = 123L;
+    byte[] array = new byte[0];
+
+    @Test
+    public void testArrayAndNativeItemWriteMultipleSocketInteractions() throws IOException {
+        Session.ArrayAndNativeQueueItem item = new Session.ArrayAndNativeQueueItem(
+                array, 5, nativeAddress, 9, mockedListener);
+
+        ArgumentCaptor<Integer> offsetArray = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> lengthArray = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> offsetNative = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> lengthNative = ArgumentCaptor.forClass(Integer.class);
+
+        Mockito.when(mockedSocket.write(eq(array), offsetArray.capture(), lengthArray.capture(), eq(0))).
+                thenReturn(2).
+                thenReturn(0).
+                thenReturn(3).thenThrow(IllegalStateException.class);
+        Mockito.when(mockedSocket.writeRaw(offsetNative.capture(), lengthNative.capture(), eq(0))).
+                thenReturn(4).
+                thenReturn(0).
+                thenReturn(5).thenThrow(IllegalStateException.class);
+
+        // nothing written initially
+        verifyState(item, 0, 14);
+        // write array 2 bytes
+        assertEquals(2, item.write(mockedSocket));
+        verifyState(item, 2, 14);
+        // write array 0 bytes
+        assertEquals(0, item.write(mockedSocket));
+        verifyState(item, 2, 14);
+        // write array 3 bytes and continue on native 4 bytes
+        assertEquals(3 + 4, item.write(mockedSocket));
+        verifyState(item, 9, 14);
+        // write 0 bytes
+        assertEquals(0, item.write(mockedSocket));
+        verifyState(item, 9, 14);
+        // finish write native, 5 bytes
+        assertEquals(5, item.write(mockedSocket));
+        verifyState(item, 14, 14);
+        // nothing to write
+        assertEquals(0, item.write(mockedSocket));
+        verifyState(item, 14, 14);
+
+        assertEquals(Arrays.asList(0, 2, 2), offsetArray.getAllValues());
+        assertEquals(Arrays.asList(5, 3 ,3), lengthArray.getAllValues());
+        assertEquals(Arrays.asList(nativeAddress, nativeAddress + 4, nativeAddress + 4), offsetNative.getAllValues());
+        assertEquals(Arrays.asList(9, 5, 5), lengthNative.getAllValues());
+    }
+
+    public void verifyState(Session.ArrayAndNativeQueueItem item, int writtenTotal, int total) {
+        assertEquals(total - writtenTotal, item.remaining());
+        item.release(null);
+        verify(mockedListener).onDone(writtenTotal, total, null);
+        reset(mockedListener);
+    }
+
+    @Test
+    public void testArrayAndNativeItemWriteSingleSocketInteraction() throws IOException {
+        Session.ArrayAndNativeQueueItem item = new Session.ArrayAndNativeQueueItem(array, 5, nativeAddress, 9, null);
+
+        ArgumentCaptor<Integer> offsetArray = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> lengthArray = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> offsetNative = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> lengthNative = ArgumentCaptor.forClass(Integer.class);
+
+        Mockito.when(mockedSocket.write(eq(array), offsetArray.capture(), lengthArray.capture(), eq(0))).thenReturn(5).
+                thenThrow(IllegalStateException.class);
+        Mockito.when(mockedSocket.writeRaw(offsetNative.capture(), lengthNative.capture(), eq(0))).thenReturn(9).
+                thenThrow(IllegalStateException.class);
+
+        assertEquals(14, item.remaining());
+        assertEquals(14, item.write(mockedSocket)); // everything written
+        assertEquals(0, item.remaining());
+        assertEquals(0, item.write(mockedSocket)); // nothing more should be written
+        assertEquals(0, item.remaining());
+
+        assertEquals(Collections.singletonList(0), offsetArray.getAllValues());
+        assertEquals(Collections.singletonList(5), lengthArray.getAllValues());
+        assertEquals(Collections.singletonList(nativeAddress), offsetNative.getAllValues());
+        assertEquals(Collections.singletonList(9), lengthNative.getAllValues());
+    }
+
+    @Test
+    public void testArrayAndNativeItemWriteJustArray() throws IOException {
+        Session.ArrayAndNativeQueueItem item = new Session.ArrayAndNativeQueueItem(array, 5, 0, 0, null);
+
+        ArgumentCaptor<Integer> offsetArray = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> lengthArray = ArgumentCaptor.forClass(Integer.class);
+
+        Mockito.when(mockedSocket.write(eq(array), offsetArray.capture(), lengthArray.capture(), eq(0))).thenReturn(5).
+                thenThrow(IllegalStateException.class);
+        Mockito.when(mockedSocket.writeRaw(ArgumentMatchers.anyLong(), ArgumentMatchers.anyInt(), eq(0))).
+                thenThrow(IllegalStateException.class);
+
+        assertEquals(5, item.remaining());
+        assertEquals(5, item.write(mockedSocket)); // everything written
+        assertEquals(0, item.remaining());
+
+        assertEquals(Collections.singletonList(0), offsetArray.getAllValues());
+        assertEquals(Collections.singletonList(5), lengthArray.getAllValues());
+    }
+
+    @Test
+    public void testArrayAndNativeItemJustNative() throws IOException {
+        Session.ArrayAndNativeQueueItem item = new Session.ArrayAndNativeQueueItem(null, 0, nativeAddress, 9, null);
+
+        ArgumentCaptor<Integer> offsetNative = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> lengthNative = ArgumentCaptor.forClass(Integer.class);
+
+        Mockito.when(mockedSocket.write(ArgumentMatchers.any(byte[].class), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())).
+                thenThrow(IllegalStateException.class);
+        Mockito.when(mockedSocket.writeRaw(offsetNative.capture(), lengthNative.capture(), eq(0))).thenReturn(9).
+                thenThrow(IllegalStateException.class);
+
+        assertEquals(9, item.remaining());
+        assertEquals(9, item.write(mockedSocket)); // everything written
+        assertEquals(0, item.remaining());
+        assertEquals(0, item.write(mockedSocket)); // nothing more should be written
+        assertEquals(0, item.remaining());
+
+        assertEquals(Collections.singletonList(nativeAddress), offsetNative.getAllValues());
+        assertEquals(Collections.singletonList(9), lengthNative.getAllValues());
+    }
+}


### PR DESCRIPTION
Basically what I am missing from the library:

- Put ByteBuffer or native memory body into the http response
- Have a completion listener

Let me know if you would do anything differently and I'll change it. Don't want to maintain my own fork of this. Thank you for making this library public. It is a charm to work with it and easy to extend.

I refined the code some more.

The only breaking change is this:

- QueueItem#release takes Throwable to signal problems. No-arg release method removed. It would be to much confusion which gets called. I think it is nice to have this. But don't mind if we don't. I only care to know if written == totalCount meaning everything is sent.