### PR TITLE
Emit checkcast to avoid crash on fastdebug vm

### DIFF
--- a/src/one/nio/serial/gen/DelegateGenerator.java
+++ b/src/one/nio/serial/gen/DelegateGenerator.java
@@ -93,7 +93,7 @@ public class DelegateGenerator extends BytecodeGenerator {
         generateWrite(cv, cls, fds);
         generateRead(cv, cls, fds, defaultFields);
         generateSkip(cv, fds);
-        generateToJson(cv, fds);
+        generateToJson(cv, cls, fds);
         generateFromJson(cv, cls, fds, defaultFields);
 
         cv.visitEnd();
@@ -116,6 +116,9 @@ public class DelegateGenerator extends BytecodeGenerator {
         MethodVisitor mv = cv.visitMethod(ACC_PUBLIC | ACC_FINAL, "calcSize", "(Ljava/lang/Object;Lone/nio/serial/CalcSizeStream;)V",
                 null, new String[] { "java/io/IOException" });
         mv.visitCode();
+        mv.visitVarInsn(ALOAD, 1);
+        emitTypeCast(mv, Object.class, cls);
+        mv.visitVarInsn(ASTORE, 1);
 
         Method writeObjectMethod = JavaInternals.findMethodRecursively(cls, "writeObject", ObjectOutputStream.class);
         if (writeObjectMethod != null && !Repository.hasOptions(writeObjectMethod.getDeclaringClass(), Repository.SKIP_WRITE_OBJECT)) {
@@ -163,6 +166,9 @@ public class DelegateGenerator extends BytecodeGenerator {
         MethodVisitor mv = cv.visitMethod(ACC_PUBLIC | ACC_FINAL, "write", "(Ljava/lang/Object;Lone/nio/serial/DataStream;)V",
                 null, new String[] { "java/io/IOException" });
         mv.visitCode();
+        mv.visitVarInsn(ALOAD, 1);
+        emitTypeCast(mv, Object.class, cls);
+        mv.visitVarInsn(ASTORE, 1);
 
         Method writeObjectMethod = JavaInternals.findMethodRecursively(cls, "writeObject", ObjectOutputStream.class);
         if (writeObjectMethod != null && !Repository.hasOptions(writeObjectMethod.getDeclaringClass(), Repository.SKIP_WRITE_OBJECT)) {
@@ -308,10 +314,13 @@ public class DelegateGenerator extends BytecodeGenerator {
         mv.visitEnd();
     }
 
-    private static void generateToJson(ClassVisitor cv, FieldDescriptor[] fds) {
+    private static void generateToJson(ClassVisitor cv, Class cls, FieldDescriptor[] fds) {
         MethodVisitor mv = cv.visitMethod(ACC_PUBLIC | ACC_FINAL, "toJson", "(Ljava/lang/Object;Ljava/lang/StringBuilder;)V",
                 null, new String[] { "java/io/IOException" });
         mv.visitCode();
+        mv.visitVarInsn(ALOAD, 1);
+        emitTypeCast(mv, Object.class, cls);
+        mv.visitVarInsn(ASTORE, 1);
 
         boolean firstWritten = false;
         mv.visitVarInsn(ALOAD, 2);


### PR DESCRIPTION
At first I must say that there was an unrelated bug I inspected in VM but also found this one.
If you run [this minimal example](https://github.com/genuss/jdk8u232-minimal/blob/master/src/com/company/Main.java) on fastdebug vm (any vm will go, not just jdk8u232) you will get a crash like [this](https://gist.github.com/genuss/51c20a42882cc4026e23ef7ae0ffe69b).
As far as I understand this has no impact on release VM and will never happen there. However I suppose this is important to fix to reduce amount of VM crashes you get when you debug it.