### PR TITLE
chore: use slf4j for logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <licenses>
         <license>
             <name>Apache License Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -41,28 +41,9 @@
             <version>9.2</version>
         </dependency>
         <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.jms</groupId>
-                    <artifactId>jms</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jdmk</groupId>
-                    <artifactId>jmxtools</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jmx</groupId>
-                    <artifactId>jmxri</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/one/nio/cluster/WeightCluster.java
+++ b/src/one/nio/cluster/WeightCluster.java
@@ -16,8 +16,8 @@
 
 package one.nio.cluster;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -27,9 +27,11 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ThreadLocalRandom;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WeightCluster<T extends ServiceProvider> implements Cluster<T> {
-    protected static final Log log = LogFactory.getLog(WeightCluster.class);
+    private static final Logger log = LoggerFactory.getLogger(WeightCluster.class);
 
     protected final HashMap<T, Integer> providers = new HashMap<>();
     protected Timer monitorTimer;
@@ -65,7 +67,7 @@ public class WeightCluster<T extends ServiceProvider> implements Cluster<T> {
     @Override
     public void enableProvider(T provider) {
         if (provider.enable()) {
-            log.info("Enabled " + provider);
+            log.info("Enabled {}", provider);
             rebuildProviderSelector();
         }
     }
@@ -73,7 +75,7 @@ public class WeightCluster<T extends ServiceProvider> implements Cluster<T> {
     @Override
     public void disableProvider(T provider) {
         if (provider.disable()) {
-            log.info("Disabled " + provider);
+            log.info("Disabled {}", provider);
             rebuildProviderSelector();
             monitorTimer.schedule(new MonitoringTask(provider), monitorTimeout, monitorTimeout);
         }
@@ -181,7 +183,7 @@ public class WeightCluster<T extends ServiceProvider> implements Cluster<T> {
                     cancel();
                 }
             } catch (Throwable e) {
-                log.warn(provider + " is not available because of " + e);
+                log.warn("{} is not available", provider);
             }
         }
     }

--- a/src/one/nio/cluster/WeightCluster.java
+++ b/src/one/nio/cluster/WeightCluster.java
@@ -27,11 +27,9 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ThreadLocalRandom;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class WeightCluster<T extends ServiceProvider> implements Cluster<T> {
-    private static final Logger log = LoggerFactory.getLogger(WeightCluster.class);
+    protected static final Logger log = LoggerFactory.getLogger(WeightCluster.class);
 
     protected final HashMap<T, Integer> providers = new HashMap<>();
     protected Timer monitorTimer;
@@ -183,7 +181,7 @@ public class WeightCluster<T extends ServiceProvider> implements Cluster<T> {
                     cancel();
                 }
             } catch (Throwable e) {
-                log.warn("{} is not available", provider);
+                log.warn("{} is not available", provider, e);
             }
         }
     }

--- a/src/one/nio/gen/BytecodeGenerator.java
+++ b/src/one/nio/gen/BytecodeGenerator.java
@@ -16,13 +16,9 @@
 
 package one.nio.gen;
 
-import one.nio.mgt.Management;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.nio.file.StandardOpenOption.WRITE;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandleInfo;
@@ -34,11 +30,15 @@ import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static java.nio.file.StandardOpenOption.*;
+import one.nio.mgt.Management;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BytecodeGenerator extends ClassLoader implements BytecodeGeneratorMXBean, Opcodes {
-    private static final Log log = LogFactory.getLog(BytecodeGenerator.class);
+    private static final Logger log = LoggerFactory.getLogger(BytecodeGenerator.class);
 
     public static final BytecodeGenerator INSTANCE = new BytecodeGenerator();
 
@@ -92,7 +92,7 @@ public class BytecodeGenerator extends ClassLoader implements BytecodeGeneratorM
         try {
             Files.write(Paths.get(dumpPath, className + ".class"), classData, WRITE, CREATE, TRUNCATE_EXISTING);
         } catch (IOException e) {
-            log.error("Could not dump " + className, e);
+            log.error("Could not dump {}", className, e);
         }
     }
 

--- a/src/one/nio/http/HttpClient.java
+++ b/src/one/nio/http/HttpClient.java
@@ -24,8 +24,9 @@ import one.nio.net.SslContext;
 import one.nio.pool.PoolException;
 import one.nio.pool.SocketPool;
 import one.nio.util.Utf8;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
@@ -34,7 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public class HttpClient extends SocketPool {
-    protected static final Log log = LogFactory.getLog(HttpClient.class);
+    private static final Logger log = LoggerFactory.getLogger(HttpClient.class);
 
     protected String[] permanentHeaders;
     protected int bufferSize;
@@ -232,9 +233,7 @@ public class HttpClient extends SocketPool {
                     } else if ("close".equalsIgnoreCase(response.getHeader("Connection:"))) {
                         response.setBody(readBodyUntilClose());
                     } else {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Content-Length unspecified: " + response.toString());
-                        }
+                        log.debug("Content-Length unspecified: {}", response);
                         throw new HttpException("Content-Length unspecified");
                     }
                 }

--- a/src/one/nio/http/HttpCluster.java
+++ b/src/one/nio/http/HttpCluster.java
@@ -66,9 +66,7 @@ public class HttpCluster extends WeightCluster<HttpProvider> {
     }
 
     public Response invoke(Request request) throws ServiceUnavailableException {
-        if (log.isTraceEnabled()) {
-            log.trace(request.toString());
-        }
+        log.trace("{}", request);
 
         final int retries = this.retries;
         for (int i = 0; i < retries; i++) {
@@ -83,9 +81,9 @@ public class HttpCluster extends WeightCluster<HttpProvider> {
                 }
                 if ((e instanceof SocketTimeoutException || e.getCause() instanceof SocketTimeoutException)
                         && !(log.isTraceEnabled() || logTimeouts)) {
-                    log.debug(provider + " timed out");
+                    log.debug("{} timed out", provider);
                 } else {
-                    log.warn(provider + " invocation failed " + request.getURI(), e);
+                    log.warn("{} invocation failed {}", provider, request.getURI(), e);
                 }
             }
         }

--- a/src/one/nio/http/HttpSession.java
+++ b/src/one/nio/http/HttpSession.java
@@ -84,14 +84,10 @@ public class HttpSession extends Session {
             }
             fragmentLength = length;
         } catch (HttpException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Bad request", e);
-            }
+            log.debug("Bad request", e);
             sendError(Response.BAD_REQUEST, e.getMessage());
         } catch (BufferOverflowException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Request entity too large", e);
-            }
+            log.debug("Request entity too large", e);
             sendError(Response.REQUEST_ENTITY_TOO_LARGE, "");
         }
     }

--- a/src/one/nio/mem/OffheapMap.java
+++ b/src/one/nio/mem/OffheapMap.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class OffheapMap<K, V> implements OffheapMapMXBean {
-    private static final Logger log = LoggerFactory.getLogger(OffheapMap.class);
+    protected static final Logger log = LoggerFactory.getLogger(OffheapMap.class);
     protected static final Unsafe unsafe = JavaInternals.unsafe;
     protected static final long byteArrayOffset = JavaInternals.byteArrayOffset;
     protected static final long MB = 1024 * 1024;

--- a/src/one/nio/mem/OffheapMap.java
+++ b/src/one/nio/mem/OffheapMap.java
@@ -23,8 +23,9 @@ import one.nio.os.BatchThread;
 import one.nio.util.JavaInternals;
 import one.nio.util.QuickSelect;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import sun.misc.Unsafe;
 
 import java.util.Arrays;
@@ -34,7 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class OffheapMap<K, V> implements OffheapMapMXBean {
-    protected static final Log log = LogFactory.getLog(OffheapMap.class);
+    private static final Logger log = LoggerFactory.getLogger(OffheapMap.class);
     protected static final Unsafe unsafe = JavaInternals.unsafe;
     protected static final long byteArrayOffset = JavaInternals.byteArrayOffset;
     protected static final long MB = 1024 * 1024;
@@ -376,7 +377,7 @@ public abstract class OffheapMap<K, V> implements OffheapMapMXBean {
         for (int i = 0; i < CONCURRENCY_LEVEL; i++) {
             RWLock lock = locks[i];
             if (!lock.lockWrite(lockWaitTime)) {
-                log.debug("Could not lock segment " + i + " for cleanup");
+                log.debug("Could not lock segment {} for cleanup", i);
                 continue;
             }
 
@@ -720,12 +721,12 @@ public abstract class OffheapMap<K, V> implements OffheapMapMXBean {
                     long elapsed = System.currentTimeMillis() - startTime;
 
                     if (expired != 0) {
-                        log.info(getName() + " cleaned " + expired + " entries in " + elapsed + " ms");
+                        log.info("{} cleaned {} entries in {} ms", getName(), expired, elapsed);
                     }
                 } catch (InterruptedException e) {
                     break;
                 } catch (Throwable e) {
-                    log.error("Exception in " + getName(), e);
+                    log.error("Exception in {}", getName(), e);
                 }
             }
         }
@@ -764,8 +765,9 @@ public abstract class OffheapMap<K, V> implements OffheapMapMXBean {
             int k = entriesToClean < count ? (int) ((long) samples * entriesToClean / count) : 0;
             long expirationAge = System.currentTimeMillis() - QuickSelect.select(timestamps, k, 0, samples - 1);
 
-            log.info(getName() + " needs to clean " + entriesToClean + " entries. Samples collected = "
-                    + samples + ", age = " + expirationAge);
+            log.info("{} needs to clean {} entries. Samples collected = {}, age = {}", getName(), entriesToClean,
+                samples, expirationAge
+            );
             if (log.isDebugEnabled()) {
                 log.debug(Arrays.toString(timestamps));
             }

--- a/src/one/nio/mgt/Management.java
+++ b/src/one/nio/mgt/Management.java
@@ -16,8 +16,8 @@
 
 package one.nio.mgt;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.management.Attribute;
 import javax.management.AttributeList;
@@ -31,7 +31,7 @@ import java.util.Collections;
 import java.util.Set;
 
 public class Management {
-    private static final Log log = LogFactory.getLog(Management.class);
+    private static final Logger log = LoggerFactory.getLogger(Management.class);
 
     static {
         try {
@@ -39,7 +39,7 @@ public class Management {
             // HotspotRuntimeMBean, getHotspotMemoryMBean etc.
             ManagementFactory.getPlatformMBeanServer().createMBean("sun.management.HotspotInternal", null);
         } catch (Exception e) {
-            log.warn("Cannot register HotspotInternal: " + e);
+            log.warn("Cannot register HotspotInternal", e);
         }
     }
 
@@ -58,7 +58,7 @@ public class Management {
             }
             beanServer.registerMBean(mb, objectName);
         } catch (Exception e) {
-            log.error("Cannot register MXBean " + name, e);
+            log.error("Cannot register MXBean {}", name, e);
         }
     }
 
@@ -70,7 +70,7 @@ public class Management {
                 beanServer.unregisterMBean(objectName);
             }
         } catch (Exception e) {
-            log.error("Cannot unregister MXBean " + name, e);
+            log.error("Cannot unregister MXBean {}", name, e);
         }
     }
 

--- a/src/one/nio/mgt/ThreadDumper.java
+++ b/src/one/nio/mgt/ThreadDumper.java
@@ -16,8 +16,8 @@
 
 package one.nio.mgt;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.management.JMException;
 import java.io.OutputStream;
@@ -25,7 +25,7 @@ import java.io.PrintStream;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class ThreadDumper {
-    private static final Log log = LogFactory.getLog(ThreadDumper.class);
+    private static final Logger log = LoggerFactory.getLogger(ThreadDumper.class);
     private static final AtomicLong dumpTime = new AtomicLong();
 
     public static void dump(OutputStream out) {
@@ -33,7 +33,7 @@ public class ThreadDumper {
         try {
             threadDump = DiagnosticCommand.execute("threadPrint");
         } catch (JMException e) {
-            log.warn("Failed to get threads dump: " + e);
+            log.warn("Failed to get threads dump", e);
             return;
         }
 

--- a/src/one/nio/net/JavaSelector.java
+++ b/src/one/nio/net/JavaSelector.java
@@ -16,8 +16,8 @@
 
 package one.nio.net;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.channels.CancelledKeyException;
@@ -30,7 +30,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 final class JavaSelector extends Selector {
-    private static final Log log = LogFactory.getLog(JavaSelector.class);
+    private static final Logger log = LoggerFactory.getLogger(JavaSelector.class);
 
     private final java.nio.channels.Selector impl;
     private final ConcurrentLinkedQueue<Session> pendingSessions;

--- a/src/one/nio/net/SelectableJavaSocket.java
+++ b/src/one/nio/net/SelectableJavaSocket.java
@@ -17,8 +17,9 @@
 package one.nio.net;
 
 import one.nio.util.JavaInternals;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
@@ -35,7 +36,7 @@ import static one.nio.util.JavaInternals.unsafe;
  * @author ivan.grigoryev
  */
 public abstract class SelectableJavaSocket extends Socket {
-    private static final Log log = LogFactory.getLog(SelectableJavaSocket.class);
+    private static final Logger log = LoggerFactory.getLogger(SelectableJavaSocket.class);
 
     private static final MethodHandle poll = getMethodHandle("sun.nio.ch.Net", "poll", FileDescriptor.class, int.class, long.class);
     private static final MethodHandle getFD = getMethodHandle("sun.nio.ch.SelChImpl", "getFD");

--- a/src/one/nio/net/Session.java
+++ b/src/one/nio/net/Session.java
@@ -16,8 +16,8 @@
 
 package one.nio.net;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLException;
 import java.io.Closeable;
@@ -27,7 +27,7 @@ import java.net.SocketException;
 import java.nio.channels.SelectionKey;
 
 public class Session implements Closeable {
-    protected static final Log log = LogFactory.getLog(Session.class);
+    private static final Logger log = LoggerFactory.getLogger(Session.class);
 
     public static final int READABLE   = SelectionKey.OP_READ;
     public static final int WRITEABLE  = SelectionKey.OP_WRITE;
@@ -228,11 +228,11 @@ public class Session implements Closeable {
 
     public void handleException(Throwable e) {
         if (e instanceof SocketException) {
-            if (log.isDebugEnabled()) log.debug("Connection closed: " + getRemoteHost());
+            if (log.isDebugEnabled()) log.debug("Connection closed: {}", getRemoteHost());
         } else if (e instanceof SSLException) {
-            if (log.isDebugEnabled()) log.debug("SSL/TLS failure: " + getRemoteHost());
+            if (log.isDebugEnabled()) log.debug("SSL/TLS failure: {}", getRemoteHost());
         } else {
-            log.error("Cannot process session from " + getRemoteHost(), e);
+            log.error("Cannot process session from {}", getRemoteHost(), e);
         }
         close();
     }

--- a/src/one/nio/net/Session.java
+++ b/src/one/nio/net/Session.java
@@ -232,7 +232,7 @@ public class Session implements Closeable {
         } else if (e instanceof SSLException) {
             if (log.isDebugEnabled()) log.debug("SSL/TLS failure: {}", getRemoteHost());
         } else {
-            if (log.isErrorEnabled()) log.error("Cannot process session from {}", getRemoteHost(), e);
+            log.error("Cannot process session from {}", getRemoteHost(), e);
         }
         close();
     }

--- a/src/one/nio/net/Session.java
+++ b/src/one/nio/net/Session.java
@@ -27,7 +27,7 @@ import java.net.SocketException;
 import java.nio.channels.SelectionKey;
 
 public class Session implements Closeable {
-    private static final Logger log = LoggerFactory.getLogger(Session.class);
+    protected static final Logger log = LoggerFactory.getLogger(Session.class);
 
     public static final int READABLE   = SelectionKey.OP_READ;
     public static final int WRITEABLE  = SelectionKey.OP_WRITE;
@@ -232,7 +232,7 @@ public class Session implements Closeable {
         } else if (e instanceof SSLException) {
             if (log.isDebugEnabled()) log.debug("SSL/TLS failure: {}", getRemoteHost());
         } else {
-            log.error("Cannot process session from {}", getRemoteHost(), e);
+            if (log.isErrorEnabled()) log.error("Cannot process session from {}", getRemoteHost(), e);
         }
         close();
     }

--- a/src/one/nio/net/SslContext.java
+++ b/src/one/nio/net/SslContext.java
@@ -19,8 +19,9 @@ package one.nio.net;
 import one.nio.os.NativeLibrary;
 import one.nio.util.ByteArrayBuilder;
 import one.nio.util.Utf8;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLException;
 import java.io.File;
@@ -34,7 +35,7 @@ import java.util.Date;
 import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class SslContext {
-    private static final Log log = LogFactory.getLog(SslContext.class);
+    private static final Logger log = LoggerFactory.getLogger(SslContext.class);
 
     public static final int VERIFY_NONE = 0;               // client cert is not verified
     public static final int VERIFY_PEER = 1;               // client cert is verified, if provided
@@ -197,14 +198,14 @@ public abstract class SslContext {
             setPrivateKey(privateKeyFile);
         }
 
-        log.info("Certificates updated: " + new Date(maxLastModified));
+        log.info("Certificates updated: {}", new Date(maxLastModified));
         lastCertUpdate = maxLastModified;
     }
 
     void updateTicketKeys(String ticketDir, boolean force) throws IOException {
         File[] files = new File(ticketDir).listFiles();
         if (files == null || files.length == 0) {
-            log.warn("No ticket keys found in " + ticketDir);
+            log.warn("No ticket keys found in {}", ticketDir);
             return;
         }
 
@@ -224,7 +225,7 @@ public abstract class SslContext {
             }
             setTicketKeys(builder.trim());
 
-            log.info("Ticket keys updated: " + new Date(lastModified) + ", key count = " + files.length);
+            log.info("Ticket keys updated: {}, key count = {}", new Date(lastModified), files.length);
             lastTicketsUpdate = lastModified;
         }
     }
@@ -234,7 +235,7 @@ public abstract class SslContext {
         if (force || lastModified > lastOCSPUpdate) {
             setOCSP(Files.readAllBytes(Paths.get(ocspFile)));
 
-            log.info("OCSP updated: " + new Date(lastModified));
+            log.info("OCSP updated: {}", new Date(lastModified));
             lastOCSPUpdate = lastModified;
         }
     }

--- a/src/one/nio/os/Cpus.java
+++ b/src/one/nio/os/Cpus.java
@@ -33,7 +33,7 @@ public class Cpus {
     public static final BitSet PRESENT = cpus("/sys/devices/system/cpu/present");
     public static final BitSet POSSIBLE = cpus("/sys/devices/system/cpu/possible");
     public static final int COUNT = POSSIBLE.cardinality();
-    
+
     private static BitSet cpus(String rangeFile) {
         try {
             byte[] bytes = Files.readAllBytes(Paths.get(rangeFile));
@@ -47,9 +47,7 @@ public class Cpus {
             }
             return cpus;
         } catch (IOException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Failed to read {}", rangeFile, e);
-            }
+            log.debug("Failed to read {}", rangeFile, e);
             BitSet cpus = new BitSet();
             cpus.set(0, Runtime.getRuntime().availableProcessors());
             return cpus;

--- a/src/one/nio/os/Cpus.java
+++ b/src/one/nio/os/Cpus.java
@@ -18,8 +18,8 @@ package one.nio.os;
 
 import one.nio.util.Utf8;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -27,7 +27,7 @@ import java.nio.file.Paths;
 import java.util.BitSet;
 
 public class Cpus {
-    private static final Log log = LogFactory.getLog(Cpus.class);
+    private static final Logger log = LoggerFactory.getLogger(Cpus.class);
 
     public static final BitSet ONLINE = cpus("/sys/devices/system/cpu/online");
     public static final BitSet PRESENT = cpus("/sys/devices/system/cpu/present");
@@ -48,7 +48,7 @@ public class Cpus {
             return cpus;
         } catch (IOException e) {
             if (log.isDebugEnabled()) {
-                log.debug("Failed to read " + rangeFile, e);
+                log.debug("Failed to read {}", rangeFile, e);
             }
             BitSet cpus = new BitSet();
             cpus.set(0, Runtime.getRuntime().availableProcessors());

--- a/src/one/nio/os/NativeLibrary.java
+++ b/src/one/nio/os/NativeLibrary.java
@@ -20,8 +20,8 @@ import one.nio.mgt.Management;
 import one.nio.util.ByteArrayBuilder;
 import one.nio.util.Hex;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -30,7 +30,7 @@ import java.io.InputStream;
 import java.util.zip.CRC32;
 
 public final class NativeLibrary implements NativeLibraryMXBean {
-    private static final Log log = LogFactory.getLog(NativeLibrary.class);
+    private static final Logger log = LoggerFactory.getLogger(NativeLibrary.class);
 
     public static final boolean IS_SUPPORTED = isSupportedOs() && loadNativeLibrary();
 

--- a/src/one/nio/os/User.java
+++ b/src/one/nio/os/User.java
@@ -16,8 +16,8 @@
 
 package one.nio.os;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 public final class User {
-    private static final Log log = LogFactory.getLog(NativeLibrary.class);
+    private static final Logger log = LoggerFactory.getLogger(NativeLibrary.class);
 
     public static final boolean IS_SUPPORTED = NativeLibrary.IS_SUPPORTED;
 
@@ -104,7 +104,7 @@ public final class User {
                 }
             }
         } catch (IOException e) {
-            log.warn("Cannot read " + file, e);
+            log.warn("Cannot read {}", file, e);
         }
         return null;
     }

--- a/src/one/nio/os/systemd/SystemdNotify.java
+++ b/src/one/nio/os/systemd/SystemdNotify.java
@@ -49,9 +49,7 @@ public class SystemdNotify {
     public static void notify(String state) throws IOException {
         String notifySocket = System.getenv(NOTIFY_SOCKET_ENV);
         if (notifySocket == null) {
-            if (log.isDebugEnabled()) {
-                log.debug(NOTIFY_SOCKET_ENV + " environment variable is not defined");
-            }
+            log.debug(NOTIFY_SOCKET_ENV + " environment variable is not defined");
             return;
         }
 

--- a/src/one/nio/os/systemd/SystemdNotify.java
+++ b/src/one/nio/os/systemd/SystemdNotify.java
@@ -17,8 +17,9 @@
 package one.nio.os.systemd;
 
 import one.nio.net.Socket;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -30,7 +31,7 @@ import java.nio.charset.StandardCharsets;
  * @see <a href="https://www.freedesktop.org/software/systemd/man/sd_notify.html">man:sd_notify(3)</a>
  */
 public class SystemdNotify {
-    private static final Log log = LogFactory.getLog(SystemdNotify.class);
+    private static final Logger log = LoggerFactory.getLogger(SystemdNotify.class);
 
     public static final String NOTIFY_SOCKET_ENV   = "NOTIFY_SOCKET";
     public static final String READY               = "READY=1";
@@ -55,9 +56,7 @@ public class SystemdNotify {
         }
 
         try (Socket socket = Socket.createUnixSocket(Socket.SOCK_DGRAM)) {
-            if (log.isDebugEnabled()) {
-                log.debug(String.format("send '%s' to notify socket '%s'", state, notifySocket));
-            }
+            log.debug("send '{}' to notify socket '{}'", state, notifySocket);
             ByteBuffer buffer = ByteBuffer.wrap(state.getBytes(StandardCharsets.UTF_8));
             socket.send(buffer, 0, notifySocket, Socket.NO_PORT);
         }

--- a/src/one/nio/rpc/RpcPacket.java
+++ b/src/one/nio/rpc/RpcPacket.java
@@ -18,13 +18,12 @@ package one.nio.rpc;
 
 import one.nio.net.Socket;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class RpcPacket {
-    private static final Log log = LogFactory.getLog(RpcPacket.class);
+    private static final Logger log = LoggerFactory.getLogger(RpcPacket.class);
 
     private static final int WARN_PACKET_SIZE = 4 * 1024 * 1024;
     private static final int ERROR_PACKET_SIZE = 128 * 1024 * 1024;
@@ -59,7 +58,7 @@ class RpcPacket {
         if (size <= 0 || size >= ERROR_PACKET_SIZE) {
             throw new IOException("Invalid RPC packet from " + socket.getRemoteAddress());
         } else if (size >= WARN_PACKET_SIZE) {
-            log.warn("RPC packet from " + socket.getRemoteAddress() + " is too large: " + size);
+            log.warn("RPC packet from {} is too large: {}", socket.getRemoteAddress(), size);
         }
     }
 }

--- a/src/one/nio/serial/Repository.java
+++ b/src/one/nio/serial/Repository.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static java.nio.file.StandardOpenOption.*;
 
 public class Repository {
-    private static final Logger log = LoggerFactory.getLogger(Repository.class);
+    public static final Logger log = LoggerFactory.getLogger(Repository.class);
 
     static final byte[][] classLocks = new byte[64][0];
     static final ConcurrentHashMap<Class, Serializer> classMap = new ConcurrentHashMap<>(128);

--- a/src/one/nio/serial/Repository.java
+++ b/src/one/nio/serial/Repository.java
@@ -21,8 +21,8 @@ import one.nio.mgt.Management;
 import one.nio.util.Base64;
 import one.nio.util.JavaInternals;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Externalizable;
 import java.io.IOException;
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static java.nio.file.StandardOpenOption.*;
 
 public class Repository {
-    public static final Log log = LogFactory.getLog(Repository.class);
+    private static final Logger log = LoggerFactory.getLogger(Repository.class);
 
     static final byte[][] classLocks = new byte[64][0];
     static final ConcurrentHashMap<Class, Serializer> classMap = new ConcurrentHashMap<>(128);
@@ -339,7 +339,7 @@ public class Repository {
             }
 
             if (cls.isAnonymousClass()) {
-                log.warn("Trying to serialize anonymous class: " + cls.getName());
+                log.warn("Trying to serialize anonymous class: {}", cls.getName());
                 anonymousClasses.incrementAndGet();
             }
 
@@ -383,7 +383,7 @@ public class Repository {
                 }
                 serializer.generateUid();
             } catch (Throwable e) {
-                log.error("Failed to generate serialized for " + cls.getName());
+                log.error("Failed to generate serialized for {}", cls.getName());
                 throw e;
             }
 

--- a/src/one/nio/server/AcceptorThread.java
+++ b/src/one/nio/server/AcceptorThread.java
@@ -20,13 +20,12 @@ import one.nio.net.Session;
 import one.nio.net.Socket;
 import one.nio.net.SslContext;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class AcceptorThread extends Thread {
-    private static final Log log = LogFactory.getLog(AcceptorThread.class);
+    private static final Logger log = LoggerFactory.getLogger(AcceptorThread.class);
 
     final String address;
     final int port;
@@ -100,7 +99,7 @@ final class AcceptorThread extends Thread {
         try {
             serverSocket.listen(backlog);
         } catch (IOException e) {
-            log.error("Cannot start listening at " + port, e);
+            log.error("Cannot start listening at {}", port, e);
             return;
         } finally {
             server.startSync.countDown();
@@ -115,7 +114,7 @@ final class AcceptorThread extends Thread {
                 acceptedSessions++;
             } catch (RejectedSessionException e) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Rejected session from " + socket.getRemoteAddress(), e);
+                    log.debug("Rejected session from {}", socket.getRemoteAddress(), e);
                 }
                 rejectedSessions++;
                 socket.close();

--- a/src/one/nio/server/CleanupThread.java
+++ b/src/one/nio/server/CleanupThread.java
@@ -18,11 +18,12 @@ package one.nio.server;
 
 import one.nio.net.Session;
 import one.nio.os.BatchThread;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CleanupThread extends BatchThread {
-    private static final Log log = LogFactory.getLog(CleanupThread.class);
+    private static final Logger log = LoggerFactory.getLogger(CleanupThread.class);
 
     private volatile SelectorThread[] selectors;
     private volatile long keepAlive;
@@ -96,8 +97,9 @@ public class CleanupThread extends BatchThread {
                 }
 
                 if (log.isInfoEnabled() && idleCount + staleCount > 0) {
-                    log.info(idleCount + " idle + " + staleCount + " stale sessions closed in " +
-                            (System.currentTimeMillis() - cleanTime) + " ms");
+                    log.info("{} idle + {} stale sessions closed in {} ms",
+                        idleCount, staleCount, System.currentTimeMillis() - cleanTime
+                    );
                 }
             } catch (InterruptedException e) {
                 break;

--- a/src/one/nio/server/CleanupThread.java
+++ b/src/one/nio/server/CleanupThread.java
@@ -96,7 +96,7 @@ public class CleanupThread extends BatchThread {
                     }
                 }
 
-                if (log.isInfoEnabled() && idleCount + staleCount > 0) {
+                if (idleCount + staleCount > 0) {
                     log.info("{} idle + {} stale sessions closed in {} ms",
                         idleCount, staleCount, System.currentTimeMillis() - cleanTime
                     );

--- a/src/one/nio/server/Server.java
+++ b/src/one/nio/server/Server.java
@@ -21,8 +21,8 @@ import one.nio.net.Session;
 import one.nio.net.Socket;
 import one.nio.mgt.Management;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -33,7 +33,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.LongAdder;
 
 public class Server implements ServerMXBean {
-    private static final Log log = LogFactory.getLog(Server.class);
+    private static final Logger log = LoggerFactory.getLogger(Server.class);
 
     private final LongAdder requestsProcessed = new LongAdder();
     private final LongAdder requestsRejected = new LongAdder();
@@ -107,7 +107,7 @@ public class Server implements ServerMXBean {
                 AcceptorThread oldAcceptor = oldAcceptors[i];
                 if (oldAcceptor != null && oldAcceptor.port == ac.port && oldAcceptor.address.equals(ac.address)) {
                     if (++threads <= ac.threads) {
-                        log.info("Reconfiguring acceptor: " + oldAcceptor.getName());
+                        log.info("Reconfiguring acceptor: {}", oldAcceptor.getName());
                         oldAcceptor.reconfigure(ac);
                         oldAcceptors[i] = null;
                         newAcceptors.add(oldAcceptor);
@@ -117,7 +117,7 @@ public class Server implements ServerMXBean {
 
             for (; threads < ac.threads; threads++) {
                 AcceptorThread newAcceptor = new AcceptorThread(this, ac, threads);
-                log.info("New acceptor: " + newAcceptor.getName());
+                log.info("New acceptor: {}", newAcceptor.getName());
                 newAcceptor.start();
                 newAcceptors.add(newAcceptor);
             }
@@ -125,7 +125,7 @@ public class Server implements ServerMXBean {
 
         for (AcceptorThread oldAcceptor : oldAcceptors) {
             if (oldAcceptor != null) {
-                log.info("Stopping acceptor: " + oldAcceptor.getName());
+                log.info("Stopping acceptor: {}", oldAcceptor.getName());
                 oldAcceptor.shutdown();
             }
         }

--- a/src/one/nio/server/WorkerPool.java
+++ b/src/one/nio/server/WorkerPool.java
@@ -17,8 +17,9 @@
 package one.nio.server;
 
 import one.nio.os.SchedulingPolicy;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
@@ -27,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 final class WorkerPool extends ThreadPoolExecutor implements ThreadFactory, Thread.UncaughtExceptionHandler {
-    private static final Log log = LogFactory.getLog(WorkerPool.class);
+    private static final Logger log = LoggerFactory.getLogger(WorkerPool.class);
 
     private final AtomicInteger index;
     private final int threadPriority;
@@ -72,7 +73,7 @@ final class WorkerPool extends ThreadPoolExecutor implements ThreadFactory, Thre
 
     @Override
     public void uncaughtException(Thread t, Throwable e) {
-        log.error("Uncaught exception in " + t, e);
+        log.error("Uncaught exception in {}", t, e);
     }
 
     private static final class WaitingSynchronousQueue extends SynchronousQueue<Runnable> {


### PR DESCRIPTION
# Description

Log4j v1 and transitively Apache Commons Logging are subjects to multiple CVEs
(namely [CVE-2022-23307], [CVE-2022-23305], [CVE-2022-23302], [CVE-2021-4104], [CVE-2019-17571])
and both libraries have not been updated since the years 2012 and 2014 respectively.

This PR replaces them with the usage of slf4j which is more universal (being just a common API for various loggers)
and less vulnerable to potential attacks (again, being just an API).

It's worth mentioning that its v1 is used although v2 has been released about a year agi
which is due to API v2 not yet being stable enough and as well supported as v1 is.

[CVE-2022-23307]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23307
[CVE-2022-23305]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23305
[CVE-2022-23302]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23302
[CVE-2021-4104]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-4104
[CVE-2019-17571]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17571
