### PR TITLE
Support new FileChannelImpl.map0 contract

### DIFF
--- a/src/one/nio/mem/MappedFile.java
+++ b/src/one/nio/mem/MappedFile.java
@@ -174,7 +174,7 @@ public class MappedFile implements Closeable {
             map0 = JavaInternals.getMethod(
                 cls, "map0", FileDescriptor.class, int.class, long.class, long.class, boolean.class);
             if (map0 != null) {
-                return (long) map0.invoke(f.getChannel(), f.getFD(), mode, start, size, false);
+                return (long) map0.invoke(f.getFD(), f.getChannel(), mode, start, size, false);
             }
             throw new IllegalStateException("map0 method not found");
         } catch (InvocationTargetException e) {

--- a/src/one/nio/mem/MappedFile.java
+++ b/src/one/nio/mem/MappedFile.java
@@ -170,6 +170,12 @@ public class MappedFile implements Closeable {
             if (map0 != null) {
                 return (long) map0.invoke(f.getChannel(), mode, start, size, false);
             }
+            // Since 19 JDK has an extra 'file descriptor' argument
+            map0 = JavaInternals.getMethod(
+                cls, "map0", FileDescriptor.class, int.class, long.class, long.class, boolean.class);
+            if (map0 != null) {
+                return (long) map0.invoke(f.getChannel(), f.getFD(), mode, start, size, false);
+            }
             throw new IllegalStateException("map0 method not found");
         } catch (InvocationTargetException e) {
             Throwable target = e.getTargetException();


### PR DESCRIPTION
In jdk19 contact of map0() method has been changed.

Previous contract version:
`private native long map0(int prot, long position, long length, boolean isSync) throws IOException;`
https://github.com/openjdk/jdk15/blob/19b8204719c50d70fa435f9484a61365258b46c3/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java#L1341

New contract version:
`private native long map0(FileDescriptor fd, int prot, long position, long length, boolean isSync) throws IOException;`
https://github.com/openjdk/jdk19/blob/967a28c3d85fdde6d5eb48aa0edd8f7597772469/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java#L1566



