### PR TITLE
ConnectionString javadoc

### DIFF
--- a/src/one/nio/net/ConnectionString.java
+++ b/src/one/nio/net/ConnectionString.java
@@ -33,49 +33,29 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- Available HTTP params for configure directly in ConnectionString url:
-
- * keepalive            | default true
-
- * bufferSize           | default 8000
-
- * timeout              | default 3000
-
- * readTimeout          | default 3000
-
- * connectTimeout       | default 1000
-
- * fifo                 | default false
-
- * jmx                  | default false
-
- * clientMinPoolSize    | default 0
-
- * clientMaxPoolSize    | default 5000
-
- * schedulingPolicy     | default OTHER     | @see SchedulingPolicy
-
- * tos                  | default 0         | @see Socket Type of Service
-
- * recvBuf              | default 0
-
- * sendBuf              | default 0
-
- * backlog              | default 128
-
- * selectors            | default 0
-
- * minWorkers           | default 0
-
- * maxWorkers           | default 0
-
- * queueTime            | default 0
-
- * closeSessions        | default false
-
- * threadPriority       | default Thread.NORM_PRIORITY
-
- * proxy
+ * Available HTTP params for configure directly in ConnectionString url:
+ * <ul>
+ * <li>keepalive            {@code true}</li>
+ * <li>bufferSize           {@code 8000}</li>
+ * <li>timeout              {@code 3000}</li>
+ * <li>readTimeout          {@code 3000}</li>
+ * <li>connectTimeout       {@code 1000}</li>
+ * <li>fifo                 {@code false}</li>
+ * <li>jmx                  {@code false}</li>
+ * <li>clientMinPoolSize    {@code 0}</li>
+ * <li>clientMaxPoolSize    {@code 5000}</li>
+ * <li>schedulingPolicy     {@code OTHER}</li>
+ * <li>tos                  {@code 0}</li>
+ * <li>recvBuf              {@code 0}</li>
+ * <li>sendBuf              {@code 0}</li>
+ * <li>backlog              {@code 128}</li>
+ * <li>selectors            {@code 0}</li>
+ * <li>minWorkers           {@code 0}</li>
+ * <li>maxWorkers           {@code 0}</li>
+ * <li>queueTime            {@code 0}</li>
+ * <li>closeSessions        {@code false}</li>
+ * <li>threadPriority       {@code Thread.NORM_PRIORITY}</li>
+ * </ul>
  */
 public class ConnectionString {
     private static final Pattern INTERFACE_PATTERN = Pattern.compile("\\{(.+)\\}");

--- a/src/one/nio/net/ConnectionString.java
+++ b/src/one/nio/net/ConnectionString.java
@@ -32,6 +32,31 @@ import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Available params for configure:
+ * <p>
+ * keepalive            | default true
+ * bufferSize           | default 8000
+ * timeout              | default 3000
+ * readTimeout          | default 3000
+ * connectTimeout       | default 1000
+ * fifo                 | default false
+ * jmx                  | default false
+ * clientMinPoolSize    | default 0
+ * clientMaxPoolSize    | default 5000
+ * schedulingPolicy     | default OTHER     | @see SchedulingPolicy
+ * tos                  | default 0         | @see Socket Type of Service
+ * recvBuf              | default 0
+ * sendBuf              | default 0
+ * backlog              | default 128
+ * selectors            | default 0
+ * minWorkers           | default 0
+ * maxWorkers           | default 0
+ * queueTime            | default 0
+ * closeSessions        | default false
+ * threadPriority       | default Thread.NORM_PRIORITY
+ * proxy
+ */
 public class ConnectionString {
     private static final Pattern INTERFACE_PATTERN = Pattern.compile("\\{(.+)\\}");
     private static final Map<String, Integer> WELL_KNOWN_PORTS = new HashMap<>();

--- a/src/one/nio/net/ConnectionString.java
+++ b/src/one/nio/net/ConnectionString.java
@@ -33,28 +33,48 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Available params for configure:
- * <p>
+ Available HTTP params for configure directly in ConnectionString url:
+
  * keepalive            | default true
+
  * bufferSize           | default 8000
+
  * timeout              | default 3000
+
  * readTimeout          | default 3000
+
  * connectTimeout       | default 1000
+
  * fifo                 | default false
+
  * jmx                  | default false
+
  * clientMinPoolSize    | default 0
+
  * clientMaxPoolSize    | default 5000
+
  * schedulingPolicy     | default OTHER     | @see SchedulingPolicy
+
  * tos                  | default 0         | @see Socket Type of Service
+
  * recvBuf              | default 0
+
  * sendBuf              | default 0
+
  * backlog              | default 128
+
  * selectors            | default 0
+
  * minWorkers           | default 0
+
  * maxWorkers           | default 0
+
  * queueTime            | default 0
+
  * closeSessions        | default false
+
  * threadPriority       | default Thread.NORM_PRIORITY
+
  * proxy
  */
 public class ConnectionString {

--- a/src/one/nio/pool/SocketPool.java
+++ b/src/one/nio/pool/SocketPool.java
@@ -33,7 +33,7 @@ public class SocketPool extends Pool<Socket> implements SocketPoolMXBean {
 
     public SocketPool(ConnectionString conn) {
         super(conn.getIntParam("clientMinPoolSize", 0) > 0 ? 1 : 0,
-              conn.getIntParam("clientMaxPoolSize", 5000),
+              conn.getIntParam("clientMaxPoolSize", 10),
               conn.getIntParam("timeout", 3000));
 
         this.host = conn.getHost();

--- a/src/one/nio/pool/SocketPool.java
+++ b/src/one/nio/pool/SocketPool.java
@@ -33,7 +33,7 @@ public class SocketPool extends Pool<Socket> implements SocketPoolMXBean {
 
     public SocketPool(ConnectionString conn) {
         super(conn.getIntParam("clientMinPoolSize", 0) > 0 ? 1 : 0,
-              conn.getIntParam("clientMaxPoolSize", 10),
+              conn.getIntParam("clientMaxPoolSize", 5000),
               conn.getIntParam("timeout", 3000));
 
         this.host = conn.getHost();

--- a/test/one/nio/net/ConnectionStringTest.java
+++ b/test/one/nio/net/ConnectionStringTest.java
@@ -49,6 +49,19 @@ public class ConnectionStringTest {
         assertEquals("?", conn.getStringParam("question"));
         assertEquals(345, conn.getIntParam("int", 0));
 
+        conn = new ConnectionString("https://example.com?str=s&empty=?&int=123");
+        assertEquals("example.com", conn.getHost());
+        assertEquals(443, conn.getPort());
+        assertEquals("?str=s&empty=?&int=123", conn.getPath());
+        assertEquals("s", conn.getStringParam("str"));
+        assertEquals("def", conn.getStringParam("empty", "def"));
+        assertEquals(123, conn.getIntParam("int", 0));
+
+        conn = new ConnectionString("https://example.com/somePath");
+        assertEquals("example.com", conn.getHost());
+        assertEquals(443, conn.getPort());
+        assertEquals("somePath", conn.getPath());
+
         conn = new ConnectionString("socket://[::1]:12345?:=true");
         assertEquals("[::1]", conn.getHost());
         assertEquals(12345, conn.getPort());

--- a/test/one/nio/net/ConnectionStringTest.java
+++ b/test/one/nio/net/ConnectionStringTest.java
@@ -52,15 +52,15 @@ public class ConnectionStringTest {
         conn = new ConnectionString("https://example.com?str=s&empty=&int=123");
         assertEquals("example.com", conn.getHost());
         assertEquals(443, conn.getPort());
-        assertEquals("?str=s&empty=?&int=123", conn.getPath());
+        assertEquals("?str=s&empty=&int=123", conn.getPath());
         assertEquals("s", conn.getStringParam("str"));
-        assertEquals("def", conn.getStringParam("empty", "def"));
+        assertEquals("", conn.getStringParam("empty", "def"));
         assertEquals(123, conn.getIntParam("int", 0));
 
         conn = new ConnectionString("https://example.com/somePath");
         assertEquals("example.com", conn.getHost());
         assertEquals(443, conn.getPort());
-        assertEquals("somePath", conn.getPath());
+        assertEquals("/somePath", conn.getPath());
 
         conn = new ConnectionString("socket://[::1]:12345?:=true");
         assertEquals("[::1]", conn.getHost());

--- a/test/one/nio/net/ConnectionStringTest.java
+++ b/test/one/nio/net/ConnectionStringTest.java
@@ -49,7 +49,7 @@ public class ConnectionStringTest {
         assertEquals("?", conn.getStringParam("question"));
         assertEquals(345, conn.getIntParam("int", 0));
 
-        conn = new ConnectionString("https://example.com?str=s&empty=?&int=123");
+        conn = new ConnectionString("https://example.com?str=s&empty=&int=123");
         assertEquals("example.com", conn.getHost());
         assertEquals(443, conn.getPort());
         assertEquals("?str=s&empty=?&int=123", conn.getPath());


### PR DESCRIPTION
Also I have changed param **clientMaxPoolSize** from **10** to **5000** because **http client** from **one-nio** usually used for high-load system where we need a lot of connections and value 5000 more suitable for such cases. And because of poor docs it's not obvious how to increase this value. I bet a lot of developers like me starting to use http client on production and realised that the performance is terrible, although all integration tests were normal, since 10 sockets per address are enough for tests.