### PR TITLE
Http client TLS SNI extension support, api for setting ciphersuites

### DIFF
--- a/src/one/nio/net/JavaSslClientContext.java
+++ b/src/one/nio/net/JavaSslClientContext.java
@@ -65,6 +65,11 @@ public class JavaSslClientContext extends SslContext {
     }
 
     @Override
+    public void setCiphersuites(String ciphersuites) throws SSLException {
+        // Ignore
+    }
+
+    @Override
     public void setCurve(String curve) throws SSLException {
         // Ignore
     }

--- a/src/one/nio/net/NativeSslContext.java
+++ b/src/one/nio/net/NativeSslContext.java
@@ -199,6 +199,9 @@ class NativeSslContext extends SslContext {
     @Override
     public native void setCiphers(String ciphers) throws SSLException;
 
+    @Override
+    public native void setCiphersuites(String ciphersuites) throws SSLException;
+
     /**
      * Sets the curve used for ECDH temporary keys used during key exchange.
      * Use <code>openssl ecparam -list_curves</code> to get list of supported curves.

--- a/src/one/nio/net/NativeSslSocket.java
+++ b/src/one/nio/net/NativeSslSocket.java
@@ -92,7 +92,7 @@ class NativeSslSocket extends NativeSocket {
         return null;
     }
     @Override
-    public synchronized native void handshake() throws IOException;
+    public synchronized native void handshake(String sniHostName) throws IOException;
 
     @Override
     public synchronized native int writeRaw(long buf, int count, int flags) throws IOException;

--- a/src/one/nio/net/Socket.java
+++ b/src/one/nio/net/Socket.java
@@ -174,7 +174,7 @@ public abstract class Socket implements ByteChannel {
         return send(data, flags, InetAddress.getByName(host), port);
     }
 
-    public void handshake() throws IOException {
+    public void handshake(String sniHostname) throws IOException {
         // Only for SSL sockets
     }
 

--- a/src/one/nio/net/SslConfig.java
+++ b/src/one/nio/net/SslConfig.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 public class SslConfig {
     // Conservative ciphersuite according to https://wiki.mozilla.org/Security/Server_Side_TLS
     static final String DEFAULT_CIPHERS = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA";
+    static final String DEFAULT_CIPHERSUITES = "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256";
     static final String DEFAULT_CACHE_MODE = "internal";
     static final int DEFAULT_CACHE_SIZE = 262144;
     static final long DEFAULT_TIMEOUT_SEC = 300;
@@ -34,6 +35,7 @@ public class SslConfig {
     public boolean rdrand;
     public String protocols;
     public String ciphers;
+    public String ciphersuites;
     public String curve;
     public String[] certFile;
     public String[] privateKeyFile;
@@ -65,6 +67,7 @@ public class SslConfig {
         SslConfig config = new SslConfig();
         config.protocols      = props.getProperty("one.nio.ssl.protocols");
         config.ciphers        = props.getProperty("one.nio.ssl.ciphers");
+        config.ciphersuites   = props.getProperty("one.nio.ssl.ciphersuites");
         config.curve          = props.getProperty("one.nio.ssl.curve");
         config.certFile       = toArray(props.getProperty("one.nio.ssl.certFile"));
         config.privateKeyFile = toArray(props.getProperty("one.nio.ssl.privateKeyFile"));

--- a/src/one/nio/net/SslContext.java
+++ b/src/one/nio/net/SslContext.java
@@ -84,6 +84,7 @@ public abstract class SslContext {
         }
 
         setCiphers(config.ciphers != null ? config.ciphers : SslConfig.DEFAULT_CIPHERS);
+        setCiphersuites(config.ciphersuites != null ? config.ciphersuites : SslConfig.DEFAULT_CIPHERSUITES);
 
         // with null the curve will be auto-selected by openssl
         setCurve(config.curve);
@@ -307,6 +308,7 @@ public abstract class SslContext {
     public abstract void setRdrand(boolean rdrand) throws SSLException;
     public abstract void setProtocols(String protocols) throws SSLException;
     public abstract void setCiphers(String ciphers) throws SSLException;
+    public abstract void setCiphersuites(String ciphersuites) throws SSLException;
     public abstract void setCurve(String curve) throws SSLException;
     public abstract void setCertificate(String certFile) throws SSLException;
     public abstract void setPrivateKey(String privateKeyFile) throws SSLException;

--- a/src/one/nio/net/native/ssl.c
+++ b/src/one/nio/net/native/ssl.c
@@ -710,6 +710,20 @@ Java_one_nio_net_NativeSslContext_setCiphers(JNIEnv* env, jobject self, jstring 
 }
 
 JNIEXPORT void JNICALL
+Java_one_nio_net_NativeSslContext_setCiphersuites(JNIEnv* env, jobject self, jstring ciphersuites) {
+    SSL_CTX* ctx = (SSL_CTX*)(intptr_t)(*env)->GetLongField(env, self, f_ctx);
+
+    if (ciphersuites != NULL) {
+        const char* value = (*env)->GetStringUTFChars(env, ciphersuites, NULL);
+        int result = SSL_CTX_set_ciphersuites(ctx, value);
+        (*env)->ReleaseStringUTFChars(env, ciphersuites, value);
+        if (result <= 0) {
+            throw_ssl_exception(env);
+        }
+    }
+}
+
+JNIEXPORT void JNICALL
 Java_one_nio_net_NativeSslContext_setCurve(JNIEnv* env, jobject self, jstring curve) {
     SSL_CTX* ctx = (SSL_CTX*)(intptr_t)(*env)->GetLongField(env, self, f_ctx);
     if (curve != NULL) {

--- a/src/one/nio/pool/SocketPool.java
+++ b/src/one/nio/pool/SocketPool.java
@@ -177,7 +177,7 @@ public class SocketPool extends Pool<Socket> implements SocketPoolMXBean {
 
             if (sslContext != null) {
                 socket = socket.sslWrap(sslContext);
-                socket.handshake();
+                socket.handshake(host);
             }
 
             return socket;


### PR DESCRIPTION
Http client fails to handshake when connecting to https server that is doing virtual hosts. So just added SNI TLS extension when handshaking `SSL_set_tlsext_host_name`. This way the server knows which host to serve. Exception in question:

```
javax.net.ssl.SSLException: error:0A000410:SSL routines::ssl/tls alert handshake failure
    at one.nio.pool.SocketPool.createObject(SocketPool.java:186)
    at one.nio.pool.SocketPool.createObject(SocketPool.java:26)
    at one.nio.pool.Pool.borrowObject(Pool.java:93)
    at one.nio.http.HttpClient.invoke(HttpClient.java:90)
    at one.nio.http.HttpClient.invoke(HttpClient.java:82)
    at one.nio.http.HttpClient.get(HttpClient.java:121)
    at nl.digitalekabeltelevisie.util.Foo.main(Foo.java:18)
Caused by: javax.net.ssl.SSLException: error:0A000410:SSL routines::ssl/tls alert handshake failure
    at one.nio.net.NativeSslSocket.handshake(Native Method)
    at one.nio.pool.SocketPool.createObject(SocketPool.java:180)
    ... 6 more
```

Also added API support for calling `SSL_CTX_set_ciphersuites`.



