### PR TITLE
Support for Java 22+

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,8 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [8, 11, 17, 19, 21, 23]
-    env:
-      main_jdk: 8
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [8, 11, 17, 19, 21]
+        jdk: [8, 11, 17, 19, 21, 23]
     env:
       main_jdk: 8
 

--- a/src/one/nio/serial/gen/DelegateGenerator.java
+++ b/src/one/nio/serial/gen/DelegateGenerator.java
@@ -253,11 +253,6 @@ public class DelegateGenerator extends BytecodeGenerator {
         mv.visitVarInsn(ALOAD, 1);
         mv.visitTypeInsn(NEW, Type.getInternalName(cls));
         mv.visitInsn(DUP_X1);
-//        mv.visitMethodInsn(INVOKESPECIAL, Type.getInternalName(cls), "<init>", "()V", false);
-//        mv.visitVarInsn(ASTORE, 2);
-//        mv.visitVarInsn(ALOAD, 1);
-//        mv.visitVarInsn(ALOAD, 2);
-
         mv.visitMethodInsn(INVOKEVIRTUAL, "one/nio/serial/DataStream", "register", "(Ljava/lang/Object;)V", false);
 
         ArrayList<Field> parents = new ArrayList<>();
@@ -438,9 +433,6 @@ public class DelegateGenerator extends BytecodeGenerator {
 
         // Create instance
         mv.visitTypeInsn(NEW, Type.getInternalName(cls));
-        //mv.visitInsn(DUP);
-//        mv.visitMethodInsn(INVOKESPECIAL, Type.getInternalName(cls), "<init>", "()V", false);
-//        mv.visitVarInsn(ASTORE, 3);
 
         // Prepare a multimap (fieldHash -> fds) for lookupswitch
         TreeMap<Integer, FieldDescriptor> fieldHashes = new TreeMap<>();
@@ -515,7 +507,7 @@ public class DelegateGenerator extends BytecodeGenerator {
             }
             do {
                 Label next = new Label();
-                mv.visitVarInsn(ALOAD, 3);
+                mv.visitVarInsn(ALOAD, 2);
                 mv.visitLdcInsn(fd.ownField().getName());
                 mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "equals", "(Ljava/lang/Object;)Z", false);
                 mv.visitJumpInsn(IFEQ, fd.next == null ? skipUnknownField : next);

--- a/src/one/nio/serial/gen/DelegateGenerator.java
+++ b/src/one/nio/serial/gen/DelegateGenerator.java
@@ -34,6 +34,8 @@ import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.invoke.MethodHandleInfo;
@@ -59,7 +61,7 @@ public class DelegateGenerator extends BytecodeGenerator {
     private static final AtomicInteger index = new AtomicInteger();
 
     // Allows to bypass security checks when accessing private members of other classes
-    private static final String MAGIC_CLASS = "jdk/internal/reflect/MagicAccessorImpl";
+    private static final String MAGIC_CLASS = "sun/reflect/MagicAccessorImpl";
 
     // In JDK 9+ there is no more sun.reflect.MagicAccessorImpl class.
     // Instead there is package private jdk.internal.reflect.MagicAccessorImpl, which is not visible
@@ -76,9 +78,9 @@ public class DelegateGenerator extends BytecodeGenerator {
                 }
 
                 // public jdk.internal.reflect.MagicAccessorBridge extends jdk.internal.reflect.MagicAccessorImpl
-                defineBootstrapClass(m, "cafebabe00000033000a0a000300070700080700090100063c696e69743e010003282956010004436f64650c000400050100286a646b2f696e7465726e616c2f7265666c6563742f4d616769634163636573736f724272696467650100266a646b2f696e7465726e616c2f7265666c6563742f4d616769634163636573736f72496d706c042100020003000000000001000100040005000100060000001100010001000000052ab70001b1000000000000");
+                defineBootstrapClass(m, MagicAccessor.magicAccessorBridge());
                 // public sun.reflect.MagicAccessorImpl extends jdk.internal.reflect.MagicAccessorBridge
-                defineBootstrapClass(m, "cafebabe00000033000a0a000300070700080700090100063c696e69743e010003282956010004436f64650c0004000501001d73756e2f7265666c6563742f4d616769634163636573736f72496d706c0100286a646b2f696e7465726e616c2f7265666c6563742f4d616769634163636573736f72427269646765042100020003000000000001000100040005000100060000001100010001000000052ab70001b1000000000000");
+                defineBootstrapClass(m, MagicAccessor.sunMagicAccessor());
             } catch (Exception e) {
                 throw new IllegalStateException(e);
             }
@@ -86,8 +88,7 @@ public class DelegateGenerator extends BytecodeGenerator {
     }
 
     // Defines a new class by the bootstrap ClassLoader
-    private static void defineBootstrapClass(Method m, String classData) throws ReflectiveOperationException {
-        byte[] code = Hex.parseBytes(classData);
+    private static void defineBootstrapClass(Method m, byte[] code) throws ReflectiveOperationException {
         m.invoke(null, null, null, code, 0, code.length, null, null);
     }
 

--- a/src/one/nio/serial/gen/DelegateGenerator.java
+++ b/src/one/nio/serial/gen/DelegateGenerator.java
@@ -23,7 +23,6 @@ import one.nio.serial.JsonName;
 import one.nio.serial.NotSerial;
 import one.nio.serial.Repository;
 import one.nio.serial.SerializeWith;
-import one.nio.util.Hex;
 import one.nio.util.JavaFeatures;
 import one.nio.util.JavaInternals;
 import one.nio.util.MethodHandlesReflection;
@@ -34,8 +33,6 @@ import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.invoke.MethodHandleInfo;
@@ -61,7 +58,7 @@ public class DelegateGenerator extends BytecodeGenerator {
     private static final AtomicInteger index = new AtomicInteger();
 
     // Allows to bypass security checks when accessing private members of other classes
-    private static final String MAGIC_CLASS = "sun/reflect/MagicAccessorImpl";
+    static final String MAGIC_CLASS = "sun/reflect/MagicAccessorImpl";
 
     // In JDK 9+ there is no more sun.reflect.MagicAccessorImpl class.
     // Instead there is package private jdk.internal.reflect.MagicAccessorImpl, which is not visible

--- a/src/one/nio/serial/gen/DelegateGenerator.java
+++ b/src/one/nio/serial/gen/DelegateGenerator.java
@@ -59,7 +59,7 @@ public class DelegateGenerator extends BytecodeGenerator {
     private static final AtomicInteger index = new AtomicInteger();
 
     // Allows to bypass security checks when accessing private members of other classes
-    private static final String MAGIC_CLASS = "sun/reflect/MagicAccessorImpl";
+    private static final String MAGIC_CLASS = "jdk/internal/reflect/MagicAccessorImpl";
 
     // In JDK 9+ there is no more sun.reflect.MagicAccessorImpl class.
     // Instead there is package private jdk.internal.reflect.MagicAccessorImpl, which is not visible
@@ -252,6 +252,11 @@ public class DelegateGenerator extends BytecodeGenerator {
         mv.visitVarInsn(ALOAD, 1);
         mv.visitTypeInsn(NEW, Type.getInternalName(cls));
         mv.visitInsn(DUP_X1);
+//        mv.visitMethodInsn(INVOKESPECIAL, Type.getInternalName(cls), "<init>", "()V", false);
+//        mv.visitVarInsn(ASTORE, 2);
+//        mv.visitVarInsn(ALOAD, 1);
+//        mv.visitVarInsn(ALOAD, 2);
+
         mv.visitMethodInsn(INVOKEVIRTUAL, "one/nio/serial/DataStream", "register", "(Ljava/lang/Object;)V", false);
 
         ArrayList<Field> parents = new ArrayList<>();
@@ -432,6 +437,9 @@ public class DelegateGenerator extends BytecodeGenerator {
 
         // Create instance
         mv.visitTypeInsn(NEW, Type.getInternalName(cls));
+        //mv.visitInsn(DUP);
+//        mv.visitMethodInsn(INVOKESPECIAL, Type.getInternalName(cls), "<init>", "()V", false);
+//        mv.visitVarInsn(ASTORE, 3);
 
         // Prepare a multimap (fieldHash -> fds) for lookupswitch
         TreeMap<Integer, FieldDescriptor> fieldHashes = new TreeMap<>();
@@ -506,7 +514,7 @@ public class DelegateGenerator extends BytecodeGenerator {
             }
             do {
                 Label next = new Label();
-                mv.visitVarInsn(ALOAD, 2);
+                mv.visitVarInsn(ALOAD, 3);
                 mv.visitLdcInsn(fd.ownField().getName());
                 mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "equals", "(Ljava/lang/Object;)Z", false);
                 mv.visitJumpInsn(IFEQ, fd.next == null ? skipUnknownField : next);

--- a/src/one/nio/serial/gen/MagicAccessor.java
+++ b/src/one/nio/serial/gen/MagicAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Odnoklassniki Ltd, Mail.Ru Group
+ * Copyright 2025 VK
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/one/nio/serial/gen/MagicAccessor.java
+++ b/src/one/nio/serial/gen/MagicAccessor.java
@@ -1,0 +1,48 @@
+package one.nio.serial.gen;
+
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class MagicAccessor {
+
+    public static byte[] magicAccessorBridge() {
+        String superClass;
+        if (hasSerializationConstructorAccessor()) {
+            superClass = "jdk/internal/reflect/SerializationConstructorAccessorImpl";
+        } else {
+            superClass = "jdk/internal/reflect/MagicAccessorImpl";
+        }
+
+        return generateClass("jdk/internal/reflect/MagicAccessorBridge", superClass);
+    }
+
+    public static byte[] sunMagicAccessor() {
+        return generateClass("sun/reflect/MagicAccessorImpl", "jdk/internal/reflect/MagicAccessorBridge");
+    }
+
+    private static boolean hasSerializationConstructorAccessor() {
+        try {
+            Class.forName("jdk.internal.reflect.SerializationConstructorAccessorImpl");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+
+    private static byte[] generateClass(String name, String superClass) {
+        ClassWriter cv = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+        cv.visit(Opcodes.V1_6, Opcodes.ACC_PUBLIC, name, null, superClass, new String[]{});
+        MethodVisitor mv = cv.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+        mv.visitCode();
+
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, superClass, "<init>", "()V", false);
+        mv.visitInsn(Opcodes.RETURN);
+        mv.visitEnd();
+        cv.visitEnd();
+        return cv.toByteArray();
+    }
+
+}

--- a/src/one/nio/serial/gen/MagicAccessor.java
+++ b/src/one/nio/serial/gen/MagicAccessor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Odnoklassniki Ltd, Mail.Ru Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package one.nio.serial.gen;
 
 import org.objectweb.asm.ClassWriter;
@@ -5,10 +21,10 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
 public class MagicAccessor {
-
+    
     public static byte[] magicAccessorBridge() {
         String superClass;
-        if (hasSerializationConstructorAccessor()) {
+        if (useSerializationConstructorAccessor()) {
             superClass = "jdk/internal/reflect/SerializationConstructorAccessorImpl";
         } else {
             superClass = "jdk/internal/reflect/MagicAccessorImpl";
@@ -18,16 +34,13 @@ public class MagicAccessor {
     }
 
     public static byte[] sunMagicAccessor() {
-        return generateClass("sun/reflect/MagicAccessorImpl", "jdk/internal/reflect/MagicAccessorBridge");
+        return generateClass(DelegateGenerator.MAGIC_CLASS, "jdk/internal/reflect/MagicAccessorBridge");
     }
 
-    private static boolean hasSerializationConstructorAccessor() {
-        try {
-            Class.forName("jdk.internal.reflect.SerializationConstructorAccessorImpl");
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
+    private static boolean useSerializationConstructorAccessor() {
+        String javaVersion = System.getProperty("java.version");
+        int majorVersion = Integer.parseInt(javaVersion.substring(0, javaVersion.indexOf(".")));
+        return majorVersion >= 22;
     }
 
 

--- a/src/one/nio/serial/gen/MagicAccessor.java
+++ b/src/one/nio/serial/gen/MagicAccessor.java
@@ -43,7 +43,6 @@ public class MagicAccessor {
         return majorVersion >= 22;
     }
 
-
     private static byte[] generateClass(String name, String superClass) {
         ClassWriter cv = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
         cv.visit(Opcodes.V1_6, Opcodes.ACC_PUBLIC, name, null, superClass, new String[]{});

--- a/test/one/nio/serial/JsonReaderTest.java
+++ b/test/one/nio/serial/JsonReaderTest.java
@@ -21,19 +21,12 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-
 public class JsonReaderTest {
-
-    static {
-        System.setProperty("one.nio.gen.dump", "/Users/ale.volkov/work/one-nio/dump");
-    }
-    
     private static final String sample = "[{\n" +
             "  \"created_at\": \"Thu Jun 22 21:00:00 +0000 2017\",\n" +
             "  \"id\": 877994604561387500,\n" +

--- a/test/one/nio/serial/JsonReaderTest.java
+++ b/test/one/nio/serial/JsonReaderTest.java
@@ -21,12 +21,19 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+
 public class JsonReaderTest {
+
+    static {
+        System.setProperty("one.nio.gen.dump", "/Users/ale.volkov/work/one-nio/dump");
+    }
+    
     private static final String sample = "[{\n" +
             "  \"created_at\": \"Thu Jun 22 21:00:00 +0000 2017\",\n" +
             "  \"id\": 877994604561387500,\n" +


### PR DESCRIPTION
Fix #80

Problem indeed introduced in [this change]( https://github.com/openjdk/jdk/commit/9bfe415f66cc169249d83fc161c9c4496fe239f6#diff-841c9baffbd8f2bb59b10024176ecabd4726b0a85d865b3e57d6940819e5c745R271). Despite code comment MagicAccessorImpl is not prevent bytecode verification anymore. 

Also added separate build configuration for jdk 23 