### PR TITLE
MagicAccessor#useSerializationConstructorAccessor throws if dot is missing from java version property

### DIFF
--- a/src/one/nio/serial/gen/MagicAccessor.java
+++ b/src/one/nio/serial/gen/MagicAccessor.java
@@ -39,7 +39,13 @@ public class MagicAccessor {
 
     private static boolean useSerializationConstructorAccessor() {
         String javaVersion = System.getProperty("java.version");
-        int majorVersion = Integer.parseInt(javaVersion.substring(0, javaVersion.indexOf(".")));
+        final int indexOfDot = javaVersion.indexOf(".");
+
+        if (indexOfDot > 0) {
+            javaVersion = javaVersion.substring(0, indexOfDot);
+        }
+
+        int majorVersion = Integer.parseInt(javaVersion);
         return majorVersion >= 22;
     }
 


### PR DESCRIPTION
Seeing exception thrown instead of true/false while trying out OpenJDK 24 RC.

Edit: OpenJDK 24 RC, returns `24` for `java.version` property, no dots.