### PR TITLE
Migration to Foreign Function & Memory API (Draft)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,9 @@ dependencies {
     implementation(group = "org.ow2.asm", name = "asm", version = "9.2")
     implementation(group = "org.slf4j", name = "slf4j-api", version = "1.7.36")
 
+    implementation("org.openjdk.jmh:jmh-core:1.37")
+    annotationProcessor("org.openjdk.jmh:jmh-generator-annprocess:1.37")
+
     testImplementation(group = "junit", name = "junit", version = "4.13.1")
     testImplementation(group = "org.apache.logging.log4j", name = "log4j-slf4j-impl", version = "2.24.3")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,12 +33,12 @@ java {
 }
 
 tasks.withType<JavaCompile> {
-    sourceCompatibility = "1.8"
-    targetCompatibility = "1.8"
+    sourceCompatibility = "22"
+    targetCompatibility = "22"
     options.encoding = "UTF-8"
     options.compilerArgs = options.compilerArgs + "-Xlint:all"
+    options.compilerArgs = options.compilerArgs + "--add-opens=java.base/sun.security=ALL-UNNAMED"
 }
-
 tasks.withType<Test> {
     useJUnit()
     testLogging {

--- a/src/main/java/one/nio/mem/MappedFile.java
+++ b/src/main/java/one/nio/mem/MappedFile.java
@@ -147,7 +147,7 @@ public class MappedFile implements Closeable {
         if (ByteOrder.nativeOrder().equals(order)) {
             throw new UnsupportedOperationException("Native byte order is not implemeneted");
         }
-        return new DataStream(addr, size);
+        return new DataStream(size);
     }
 
     public static long map(RandomAccessFile f, int mode, long start, long size) throws IOException {

--- a/src/main/java/one/nio/mem/SharedMemoryMap.java
+++ b/src/main/java/one/nio/mem/SharedMemoryMap.java
@@ -189,7 +189,7 @@ public abstract class SharedMemoryMap<K, V> extends OffheapMap<K, V> implements 
     protected V valueAt(long entry) {
         try {
             long valueAddress = entry + headerSize(entry);
-            return serializer.read(new DeserializeStream(valueAddress, Integer.MAX_VALUE));
+            return serializer.read(new DeserializeStream(Integer.MAX_VALUE));
         } catch (IOException | ClassNotFoundException e) {
             throw new IllegalStateException(e);
         }
@@ -199,7 +199,7 @@ public abstract class SharedMemoryMap<K, V> extends OffheapMap<K, V> implements 
     protected void setValueAt(long entry, V value) {
         try {
             long valueAddress = entry + headerSize(entry);
-            serializer.write(value, new SerializeStream(valueAddress, Integer.MAX_VALUE));
+            serializer.write(value, new SerializeStream(Integer.MAX_VALUE));
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
@@ -274,7 +274,7 @@ public abstract class SharedMemoryMap<K, V> extends OffheapMap<K, V> implements 
         }
 
         int count = 0;
-        DeserializeStream ds = new DeserializeStream(mmap.getAddr() + CUSTOM_DATA_OFFSET, metadataSize);
+        DeserializeStream ds = new DeserializeStream(metadataSize);
         while (ds.available() > 0) {
             try {
                 Repository.provideSerializer((Serializer) ds.readObject());
@@ -321,7 +321,7 @@ public abstract class SharedMemoryMap<K, V> extends OffheapMap<K, V> implements 
             }
         });
 
-        SerializeStream ss = new SerializeStream(mmap.getAddr() + CUSTOM_DATA_OFFSET, MAX_CUSTOM_DATA_SIZE);
+        SerializeStream ss = new SerializeStream(MAX_CUSTOM_DATA_SIZE);
         try {
             for (Serializer serializer : serializers) {
                 ss.writeObject(serializer);
@@ -354,7 +354,7 @@ public abstract class SharedMemoryMap<K, V> extends OffheapMap<K, V> implements 
                     long currentPtr = mapBase + (long) i * 8;
                     for (long entry; (entry = unsafe.getAddress(currentPtr)) != 0; currentPtr = entry + NEXT_OFFSET) {
                         int headerSize = headerSize(entry);
-                        V value = oldSerializer.read(new DeserializeStream(entry + headerSize, Integer.MAX_VALUE));
+                        V value = oldSerializer.read(new DeserializeStream(Integer.MAX_VALUE));
 
                         int oldSize = sizeOf(entry);
                         int newSize = sizeOf(value);
@@ -366,7 +366,7 @@ public abstract class SharedMemoryMap<K, V> extends OffheapMap<K, V> implements 
                             entry = newEntry;
                         }
 
-                        newSerializer.write(value, new SerializeStream(entry + headerSize, Integer.MAX_VALUE));
+                        newSerializer.write(value, new SerializeStream(Integer.MAX_VALUE));
                         converted++;
                     }
                 }

--- a/src/main/java/one/nio/net/NativeSslContext.java
+++ b/src/main/java/one/nio/net/NativeSslContext.java
@@ -186,7 +186,7 @@ class NativeSslContext extends SslContext {
                 break;
             case "external":
                 setCacheMode(CacheMode.EXTERNAL);
-                SslSessionCache.Singleton.setCapacity(size);
+//                SslSessionCache.Singleton.setCapacity(size);
                 break;
             default:
                 throw new SSLException("Unsupported session cache mode: " + mode);

--- a/src/main/java/one/nio/net/SslSessionCache.java
+++ b/src/main/java/one/nio/net/SslSessionCache.java
@@ -16,101 +16,101 @@
 
 package one.nio.net;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import sun.security.util.Cache;
-
-import java.util.Objects;
-
-public interface SslSessionCache {
-    Logger log = LoggerFactory.getLogger(SslSessionCache.class);
-
-    void resize(int maxSize);
-
-    void addSession(byte[] sessionId, byte[] session);
-
-    byte[] getSession(byte[] sessionId);
-
-    void removeSession(byte[] sessionId);
-
-
-    class Singleton {
-        private static volatile SslSessionCache INSTANCE;
-        private static Singleton.Factory FACTORY = Default::new;
-        private static int CAPACITY = Default.CAPACITY;
-
-        public interface Factory {
-            SslSessionCache create(int size);
-        }
-
-        public synchronized static void setFactory(Factory factory) {
-            if (INSTANCE != null) {
-                throw new IllegalStateException("Unable to change factory after lazy instantiation is done");
-            }
-            Singleton.FACTORY = Objects.requireNonNull(factory);
-        }
-
-        public synchronized static void setCapacity(int capacity) {
-            if (capacity < 0) {
-                throw new IllegalArgumentException("Capacity must be positive");
-            }
-            if (INSTANCE != null && CAPACITY != capacity) {
-                INSTANCE.resize(capacity);
-            }
-            Singleton.CAPACITY = capacity;
-        }
-
-        public static SslSessionCache getInstance() {
-            if (INSTANCE == null) {
-                synchronized (Singleton.class) {
-                    if (INSTANCE == null) {
-                        INSTANCE = FACTORY.create(CAPACITY);
-                    }
-                }
-            }
-            return INSTANCE;
-        }
-
-        private synchronized static void clearInstance() {
-            Singleton.INSTANCE = null;
-        }
-    }
-
-    class Default implements SslSessionCache {
-        private final Cache<Cache.EqualByteArray, byte[]> cache;
-        static int CAPACITY = 1024;
-
-        private static Cache.EqualByteArray toKey(byte[] bytes) {
-            return new Cache.EqualByteArray(bytes);
-        }
-
-        public Default(int maxSize) {
-            this.cache = Cache.newSoftMemoryCache(maxSize);
-        }
-
-        public Default() {
-            this(Default.CAPACITY);
-        }
-
-        @Override
-        public void resize(int maxSize) {
-            cache.setCapacity(maxSize);
-        }
-
-        @Override
-        public void addSession(byte[] sessionId, byte[] session) {
-            cache.put(toKey(sessionId), session);
-        }
-
-        @Override
-        public byte[] getSession(byte[] sessionId) {
-            return cache.get(toKey(sessionId));
-        }
-
-        @Override
-        public void removeSession(byte[] sessionId) {
-            cache.remove(toKey(sessionId));
-        }
-    }
-}
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+//
+//import sun.security.util.Cache;
+//
+//import java.util.Objects;
+//
+//public interface SslSessionCache {
+//    Logger log = LoggerFactory.getLogger(SslSessionCache.class);
+//
+//    void resize(int maxSize);
+//
+//    void addSession(byte[] sessionId, byte[] session);
+//
+//    byte[] getSession(byte[] sessionId);
+//
+//    void removeSession(byte[] sessionId);
+//
+//
+//    class Singleton {
+//        private static volatile SslSessionCache INSTANCE;
+//        private static Singleton.Factory FACTORY = Default::new;
+//        private static int CAPACITY = Default.CAPACITY;
+//
+//        public interface Factory {
+//            SslSessionCache create(int size);
+//        }
+//
+//        public synchronized static void setFactory(Factory factory) {
+//            if (INSTANCE != null) {
+//                throw new IllegalStateException("Unable to change factory after lazy instantiation is done");
+//            }
+//            Singleton.FACTORY = Objects.requireNonNull(factory);
+//        }
+//
+//        public synchronized static void setCapacity(int capacity) {
+//            if (capacity < 0) {
+//                throw new IllegalArgumentException("Capacity must be positive");
+//            }
+//            if (INSTANCE != null && CAPACITY != capacity) {
+//                INSTANCE.resize(capacity);
+//            }
+//            Singleton.CAPACITY = capacity;
+//        }
+//
+//        public static SslSessionCache getInstance() {
+//            if (INSTANCE == null) {
+//                synchronized (Singleton.class) {
+//                    if (INSTANCE == null) {
+//                        INSTANCE = FACTORY.create(CAPACITY);
+//                    }
+//                }
+//            }
+//            return INSTANCE;
+//        }
+//
+//        private synchronized static void clearInstance() {
+//            Singleton.INSTANCE = null;
+//        }
+//    }
+//
+//    class Default implements SslSessionCache {
+//        private final Cache<Cache.EqualByteArray, byte[]> cache;
+//        static int CAPACITY = 1024;
+//
+//        private static Cache.EqualByteArray toKey(byte[] bytes) {
+//            return new Cache.EqualByteArray(bytes);
+//        }
+//
+//        public Default(int maxSize) {
+//            this.cache = Cache.newSoftMemoryCache(maxSize);
+//        }
+//
+//        public Default() {
+//            this(Default.CAPACITY);
+//        }
+//
+//        @Override
+//        public void resize(int maxSize) {
+//            cache.setCapacity(maxSize);
+//        }
+//
+//        @Override
+//        public void addSession(byte[] sessionId, byte[] session) {
+//            cache.put(toKey(sessionId), session);
+//        }
+//
+//        @Override
+//        public byte[] getSession(byte[] sessionId) {
+//            return cache.get(toKey(sessionId));
+//        }
+//
+//        @Override
+//        public void removeSession(byte[] sessionId) {
+//            cache.remove(toKey(sessionId));
+//        }
+//    }
+//}

--- a/src/main/java/one/nio/serial/DataStream.java
+++ b/src/main/java/one/nio/serial/DataStream.java
@@ -343,11 +343,6 @@ public class DataStream implements ObjectInput, ObjectOutput {
     public void read(ByteBuffer dst) throws IOException {
         int len = dst.remaining();
         long offset = alloc(len);
-//        if (dst.hasArray()) {
-//            unsafe.copyMemory(array, offset, dst.array(), byteArrayOffset + dst.arrayOffset() + dst.position(), len);
-//        } else {
-//            unsafe.copyMemory(array, offset, null, DirectMemory.getAddress(dst) + dst.position(), len);
-//        }
         MemorySegment dstSegment = MemorySegment.ofBuffer(dst);
         MemorySegment.copy(segment, JAVA_BYTE, offset, dstSegment, JAVA_BYTE, 0, len);
         dst.position(dst.limit());

--- a/src/main/java/one/nio/serial/DataStream.java
+++ b/src/main/java/one/nio/serial/DataStream.java
@@ -23,40 +23,72 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 
+import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_CHAR_UNALIGNED;
+import static java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED;
+import static java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED;
+import static java.lang.foreign.ValueLayout.JAVA_SHORT_UNALIGNED;
 import static one.nio.util.JavaInternals.*;
 
 public class DataStream implements ObjectInput, ObjectOutput {
-    protected static final byte REF_NULL       = -1;
-    protected static final byte REF_RECURSIVE  = -2;
+    private static final VarHandle B_HANDLE;
+    private static final VarHandle BOOL_HANDLE;
+    private static final VarHandle SH_HANDLE;
+    private static final VarHandle CH_HANDLE;
+    private static final VarHandle I_HANDLE;
+    private static final VarHandle L_HANDLE;
+
+    static {
+        B_HANDLE = JAVA_BYTE.varHandle().withInvokeExactBehavior();
+        BOOL_HANDLE = JAVA_BOOLEAN.varHandle().withInvokeExactBehavior();
+        SH_HANDLE = JAVA_SHORT_UNALIGNED.varHandle().withInvokeExactBehavior();
+        CH_HANDLE = JAVA_CHAR_UNALIGNED.varHandle().withInvokeExactBehavior();
+        I_HANDLE = JAVA_INT_UNALIGNED.varHandle().withInvokeExactBehavior();
+        L_HANDLE = JAVA_LONG_UNALIGNED.varHandle().withInvokeBehavior();
+    }
+
+    protected static final byte REF_NULL = -1;
+    protected static final byte REF_RECURSIVE = -2;
     protected static final byte REF_RECURSIVE2 = -3;
-    protected static final byte REF_EMBEDDED   = -4;
+    protected static final byte REF_EMBEDDED = -4;
     protected static final byte FIRST_BOOT_UID = -10;
     protected static final int INITIAL_ARRAY_CAPACITY = 400;
 
+    protected MemorySegment segment;
     protected byte[] array;
     protected long address;
     protected long limit;
     protected long offset;
 
+    public DataStream(MemorySegment segment) {
+        this.segment = segment;
+        this.limit = segment.byteSize();
+        this.offset = 0;
+    }
+
     public DataStream(int capacity) {
-        this(new byte[capacity], byteArrayOffset, capacity);
+        this(new byte[capacity], capacity);
     }
 
     public DataStream(byte[] array) {
-        this(array, byteArrayOffset, array.length);
+        this(array, array.length);
     }
 
-    public DataStream(long address, long length) {
-        this(null, address, length);
+    public DataStream(long length) {
+        this(null, length);
     }
 
-    protected DataStream(byte[] array, long address, long length) {
+    protected DataStream(byte[] array, long length) {
         this.array = array;
-        this.address = address;
-        this.limit = address + length;
-        this.offset = address;
+        this.segment = MemorySegment.ofArray(array);
+        this.address = segment.address();
+        this.limit = length;
+        this.offset = 0;
     }
 
     public byte[] array() {
@@ -68,52 +100,52 @@ public class DataStream implements ObjectInput, ObjectOutput {
     }
 
     public int count() {
-        return (int) (offset - address);
+        return (int) (offset);
     }
 
     public void write(int b) throws IOException {
         long offset = alloc(1);
-        unsafe.putByte(array, offset, (byte) b);
+        B_HANDLE.set(segment, offset, (byte) b);
     }
 
     public void write(byte[] b) throws IOException {
         long offset = alloc(b.length);
-        unsafe.copyMemory(b, byteArrayOffset, array, offset, b.length);
+        MemorySegment.copy(b, 0, segment, JAVA_BYTE, offset, b.length);
     }
 
     public void write(byte[] b, int off, int len) throws IOException {
         long offset = alloc(len);
-        unsafe.copyMemory(b, byteArrayOffset + off, array, offset, len);
+        MemorySegment.copy(b, off, segment, JAVA_BYTE, offset, len);
     }
 
     public void writeBoolean(boolean v) throws IOException {
         long offset = alloc(1);
-        unsafe.putBoolean(array, offset, v);
+        BOOL_HANDLE.set(segment, offset, v);
     }
 
     public void writeByte(int v) throws IOException {
         long offset = alloc(1);
-        unsafe.putByte(array, offset, (byte) v);
+        B_HANDLE.set(segment, offset, (byte) v);
     }
 
     public void writeShort(int v) throws IOException {
         long offset = alloc(2);
-        unsafe.putShort(array, offset, Short.reverseBytes((short) v));
+        SH_HANDLE.set(segment, offset, Short.reverseBytes((short) v));
     }
 
     public void writeChar(int v) throws IOException {
         long offset = alloc(2);
-        unsafe.putChar(array, offset, Character.reverseBytes((char) v));
+        CH_HANDLE.set(segment, offset, Character.reverseBytes((char) v));
     }
 
     public void writeInt(int v) throws IOException {
         long offset = alloc(4);
-        unsafe.putInt(array, offset, Integer.reverseBytes(v));
+        I_HANDLE.set(segment, offset, Integer.reverseBytes(v));
     }
 
     public void writeLong(long v) throws IOException {
         long offset = alloc(8);
-        unsafe.putLong(array, offset, Long.reverseBytes(v));
+        L_HANDLE.set(segment, offset, Long.reverseBytes(v));
     }
 
     public void writeFloat(float v) throws IOException {
@@ -128,7 +160,7 @@ public class DataStream implements ObjectInput, ObjectOutput {
         int length = s.length();
         long offset = alloc(length);
         for (int i = 0; i < length; i++) {
-            unsafe.putByte(array, offset++, (byte) s.charAt(i));
+            B_HANDLE.set(segment, offset, (byte) s.charAt(i));
         }
     }
 
@@ -136,7 +168,7 @@ public class DataStream implements ObjectInput, ObjectOutput {
         int length = s.length();
         long offset = alloc(length * 2);
         for (int i = 0; i < length; i++) {
-            unsafe.putChar(array, offset, Character.reverseBytes(s.charAt(i)));
+            CH_HANDLE.set(segment, offset, Character.reverseBytes(s.charAt(i)));
             offset += 2;
         }
     }
@@ -149,7 +181,7 @@ public class DataStream implements ObjectInput, ObjectOutput {
             writeInt(utfLength | 0x80000000);
         }
         long offset = alloc(utfLength);
-        Utf8.write(s, array, offset);
+        Utf8.write(s, segment, offset);
     }
 
     @SuppressWarnings("unchecked")
@@ -170,11 +202,8 @@ public class DataStream implements ObjectInput, ObjectOutput {
     public void write(ByteBuffer src) throws IOException {
         int len = src.remaining();
         long offset = alloc(len);
-        if (src.hasArray()) {
-            unsafe.copyMemory(src.array(), byteArrayOffset + src.arrayOffset() + src.position(), array, offset, len);
-        } else {
-            unsafe.copyMemory(null, DirectMemory.getAddress(src) + src.position(), array, offset, len);
-        }
+        MemorySegment scrSegment = MemorySegment.ofBuffer(src);
+        MemorySegment.copy(scrSegment, JAVA_BYTE, (src.arrayOffset() + src.position()), segment, JAVA_BYTE, offset, len);
         src.position(src.limit());
     }
 
@@ -185,7 +214,7 @@ public class DataStream implements ObjectInput, ObjectOutput {
 
     public int read() throws IOException {
         long offset = alloc(1);
-        return unsafe.getByte(array, offset);
+        return segment.get(JAVA_BYTE, offset);
     }
 
     public int read(byte[] b) throws IOException {
@@ -200,12 +229,12 @@ public class DataStream implements ObjectInput, ObjectOutput {
 
     public void readFully(byte[] b) throws IOException {
         long offset = alloc(b.length);
-        unsafe.copyMemory(array, offset, b, byteArrayOffset, b.length);
+        MemorySegment.copy(segment, JAVA_BYTE, offset, b, 0, b.length);
     }
 
     public void readFully(byte[] b, int off, int len) throws IOException {
         long offset = alloc(len);
-        unsafe.copyMemory(array, offset, b, byteArrayOffset + off, len);
+        MemorySegment.copy(segment, JAVA_BYTE, offset, b, 0, b.length);
     }
 
     public long skip(long n) throws IOException {
@@ -220,42 +249,42 @@ public class DataStream implements ObjectInput, ObjectOutput {
 
     public boolean readBoolean() throws IOException {
         long offset = alloc(1);
-        return unsafe.getBoolean(array, offset);
+        return segment.get(JAVA_BOOLEAN, offset);
     }
 
     public byte readByte() throws IOException {
         long offset = alloc(1);
-        return unsafe.getByte(array, offset);
+        return segment.get(JAVA_BYTE, offset);
     }
 
     public int readUnsignedByte() throws IOException {
         long offset = alloc(1);
-        return unsafe.getByte(array, offset) & 0xff;
+        return segment.get(JAVA_BYTE, offset) & 0xff;
     }
 
     public short readShort() throws IOException {
         long offset = alloc(2);
-        return Short.reverseBytes(unsafe.getShort(array, offset));
+        return Short.reverseBytes(segment.get(JAVA_SHORT_UNALIGNED, offset));
     }
 
     public int readUnsignedShort() throws IOException {
         long offset = alloc(2);
-        return Short.reverseBytes(unsafe.getShort(array, offset)) & 0xffff;
+        return Short.reverseBytes(segment.get(JAVA_SHORT_UNALIGNED, offset)) & 0xffff;
     }
 
     public char readChar() throws IOException {
         long offset = alloc(2);
-        return Character.reverseBytes(unsafe.getChar(array, offset));
+        return Character.reverseBytes(segment.get(JAVA_CHAR_UNALIGNED, offset));
     }
 
     public int readInt() throws IOException {
         long offset = alloc(4);
-        return Integer.reverseBytes(unsafe.getInt(array, offset));
+        return Integer.reverseBytes(segment.get(JAVA_INT_UNALIGNED, offset));
     }
 
     public long readLong() throws IOException {
         long offset = alloc(8);
-        return Long.reverseBytes(unsafe.getLong(array, offset));
+        return Long.reverseBytes(segment.get(JAVA_LONG_UNALIGNED, offset));
     }
 
     public float readFloat() throws IOException {
@@ -267,17 +296,18 @@ public class DataStream implements ObjectInput, ObjectOutput {
     }
 
     public String readLine() throws IOException {
-        for (long ptr = offset; ptr < limit; ptr++) {
-            if (unsafe.getByte(array, ptr) == '\n') {
-                int length = (int) (ptr - offset);
-                int cr = length > 0 && unsafe.getByte(array, ptr - 1) == '\r' ? 1 : 0;
-                return Utf8.read(array, alloc(length + 1), length - cr);
-            }
-        }
-
-        // The last line without CR
-        int length = (int) (limit - offset);
-        return length > 0 ? Utf8.read(array, alloc(length), length) : null;
+//        for (long ptr = offset; ptr < limit; ptr++) {
+//            if (unsafe.getByte(array, ptr) == '\n') {
+//                int length = (int) (ptr - offset);
+//                int cr = length > 0 && unsafe.getByte(array, ptr - 1) == '\r' ? 1 : 0;
+//                return Utf8.read(array, alloc(length + 1), length - cr);
+//            }
+//        }
+//
+//        // The last line without CR
+//        int length = (int) (limit - offset);
+//        return length > 0 ? Utf8.read(array, alloc(length), length) : null;
+        return null;
     }
 
     public String readUTF() throws IOException {
@@ -289,7 +319,7 @@ public class DataStream implements ObjectInput, ObjectOutput {
             length = (length & 0x7fff) << 16 | readUnsignedShort();
         }
         long offset = alloc(length);
-        return Utf8.read(array, offset, length);
+        return Utf8.read(segment, offset, length);
     }
 
     public Object readObject() throws IOException, ClassNotFoundException {
@@ -313,11 +343,13 @@ public class DataStream implements ObjectInput, ObjectOutput {
     public void read(ByteBuffer dst) throws IOException {
         int len = dst.remaining();
         long offset = alloc(len);
-        if (dst.hasArray()) {
-            unsafe.copyMemory(array, offset, dst.array(), byteArrayOffset + dst.arrayOffset() + dst.position(), len);
-        } else {
-            unsafe.copyMemory(array, offset, null, DirectMemory.getAddress(dst) + dst.position(), len);
-        }
+//        if (dst.hasArray()) {
+//            unsafe.copyMemory(array, offset, dst.array(), byteArrayOffset + dst.arrayOffset() + dst.position(), len);
+//        } else {
+//            unsafe.copyMemory(array, offset, null, DirectMemory.getAddress(dst) + dst.position(), len);
+//        }
+        MemorySegment dstSegment = MemorySegment.ofBuffer(dst);
+        MemorySegment.copy(segment, JAVA_BYTE, offset, dstSegment, JAVA_BYTE, 0, len);
         dst.position(dst.limit());
     }
 
@@ -329,7 +361,7 @@ public class DataStream implements ObjectInput, ObjectOutput {
     public ByteBuffer byteBuffer(int len) throws IOException {
         long offset = alloc(len);
         if (array != null) {
-            return ByteBuffer.wrap(array, (int) (offset - byteArrayOffset), len);
+            return ByteBuffer.wrap(array, (int) (offset), len);
         } else {
             return DirectMemory.wrap(offset, len);
         }

--- a/src/main/java/one/nio/serial/DeserializeInputStream.java
+++ b/src/main/java/one/nio/serial/DeserializeInputStream.java
@@ -1,8 +1,25 @@
+/*
+ * Copyright 2025 VK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package one.nio.serial;
 
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.foreign.MemorySegment;
 import java.nio.ByteBuffer;
 
 public class DeserializeInputStream extends InputStream {
@@ -91,6 +108,7 @@ public class DeserializeInputStream extends InputStream {
                     limit = address;
                 }
                 array = newArray;
+                segment = MemorySegment.ofArray(array);
                 offset = address;
             }
             if (offset + size > limit) fillArray(size);

--- a/src/main/java/one/nio/serial/DeserializeStream.java
+++ b/src/main/java/one/nio/serial/DeserializeStream.java
@@ -18,6 +18,7 @@ package one.nio.serial;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.lang.foreign.MemorySegment;
 import java.util.Arrays;
 
 import static one.nio.util.JavaInternals.byteArrayOffset;
@@ -27,19 +28,24 @@ public class DeserializeStream extends DataStream {
 
     protected Object[] context;
     protected int contextSize;
-    
+
+    public DeserializeStream(MemorySegment segment) {
+        super(segment);
+        this.context = new Object[INITIAL_CAPACITY];
+    }
+
     public DeserializeStream(byte[] array) {
         super(array);
         this.context = new Object[INITIAL_CAPACITY];
     }
 
     public DeserializeStream(byte[] array, int length) {
-        super(array, byteArrayOffset, length);
+        super(array, length);
         this.context = new Object[INITIAL_CAPACITY];
     }
 
-    public DeserializeStream(long address, long length) {
-        super(address, length);
+    public DeserializeStream(long length) {
+        super(length);
         this.context = new Object[INITIAL_CAPACITY];
     }
 

--- a/src/main/java/one/nio/serial/ObjectInputChannel.java
+++ b/src/main/java/one/nio/serial/ObjectInputChannel.java
@@ -37,14 +37,14 @@ public class ObjectInputChannel extends DataStream {
     private long bytesRead;
 
     public ObjectInputChannel(ReadableByteChannel ch) {
-        super(0, 0);
+        super(0);
         this.ch = ch;
         this.capacity = 0;
         this.context = EMPTY_CONTEXT;
     }
 
     public ObjectInputChannel(ReadableByteChannel ch, int bufSize) {
-        super(unsafe.allocateMemory(bufSize), 0);
+        super(0);
         this.ch = ch;
         this.capacity = bufSize;
         this.context = EMPTY_CONTEXT;

--- a/src/main/java/one/nio/serial/ObjectOutputChannel.java
+++ b/src/main/java/one/nio/serial/ObjectOutputChannel.java
@@ -32,13 +32,13 @@ public class ObjectOutputChannel extends DataStream {
     private long bytesWritten;
 
     public ObjectOutputChannel(WritableByteChannel ch) {
-        super(0, 0);
+        super(0);
         this.ch = ch;
         this.context = new SerializationContext();
     }
 
     public ObjectOutputChannel(WritableByteChannel ch, int bufSize) {
-        super(unsafe.allocateMemory(bufSize), bufSize);
+        super(bufSize);
         this.ch = ch;
         this.context = new SerializationContext();
     }

--- a/src/main/java/one/nio/serial/PersistOutputStream.java
+++ b/src/main/java/one/nio/serial/PersistOutputStream.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 VK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package one.nio.serial;
 
 import java.io.IOException;

--- a/src/main/java/one/nio/serial/PersistStream.java
+++ b/src/main/java/one/nio/serial/PersistStream.java
@@ -17,6 +17,7 @@
 package one.nio.serial;
 
 import java.io.IOException;
+import java.lang.foreign.MemorySegment;
 import java.util.Arrays;
 
 public class PersistStream extends SerializeStream {
@@ -33,12 +34,16 @@ public class PersistStream extends SerializeStream {
         super(array);
     }
 
-    public PersistStream(long address, long length) {
-        super(address, length);
+    public PersistStream(long length) {
+        super(length);
     }
 
     public byte[] toByteArray() {
         return Arrays.copyOf(array, count());
+    }
+
+    public MemorySegment toReadOnlySegment() {
+        return segment.asReadOnly();
     }
 
     @Override
@@ -74,6 +79,7 @@ public class PersistStream extends SerializeStream {
         if ((offset = currentOffset + size) > limit) {
             limit = Math.max(offset, limit * 2);
             array = Arrays.copyOf(array, (int) (limit - address));
+            segment = MemorySegment.ofArray(array);
         }
         return currentOffset;
     }

--- a/src/main/java/one/nio/serial/SerializeStream.java
+++ b/src/main/java/one/nio/serial/SerializeStream.java
@@ -32,8 +32,8 @@ public class SerializeStream extends DataStream {
         this.context = new SerializationContext(contextCapacity);
     }
 
-    public SerializeStream(long address, long length) {
-        super(address, length);
+    public SerializeStream(long length) {
+        super(length);
         this.context = new SerializationContext();
     }
 

--- a/src/main/java/one/nio/serial/SerializerCollector.java
+++ b/src/main/java/one/nio/serial/SerializerCollector.java
@@ -28,7 +28,7 @@ public class SerializerCollector extends DataStream {
     }
 
     public SerializerCollector(long address, long length) {
-        super(null, address, length);
+        super(length);
     }
 
     public void setOffset(long offset) {


### PR DESCRIPTION
# Migration to Foreign Function & Memory API

## Summary
Investigate the feasibility of migrating a library from Unsafe to the new and safer Foreign Function & Memory API. This will enable the library to function in future Java versions after the removal of Unsafe functionality critical to the library.  
This is a draft version of adapting the project to new Java conditions.

## Goals
- Evaluate the use of Foreign Function & Memory API, specifically MemorySegment, for partial replacement of Unsafe. The evaluation is based solely on the one.nio.serial component.
- Assess performance degradation with the new approach.
- Identify entry points for modernizing the project to adapt to newer Java versions.

## Non-goals
- Modify the entire library; the focus at this stage is on one part of the project without ensuring compatibility with other project APIs.
- Ensure all tests pass; only the one.nio.serial component is of interest.

## Description
For this modification, I did not consider the entire project functionality that relies on serialization. Since my focus is on modernizing serialization at this stage, I intentionally commented out or skipped code sections that are not relevant.  
This branch does not support backward compatibility with Java 8; the minimum build version is set to Java 22 due to the use of Foreign Function & Memory API and operates only within Java versions 22 to 23.  
A particular interest is the performance impact after moving away from Unsafe. Initial simple performance tests indicate that abandoning Unsafe results in up to a 20% performance drop.

### With Unsafe (serialization and deserialization of a POJO object):
```
Benchmark                           Mode  Cnt      Score      Error   Units
BenchmarkRunner.testSerialization  thrpt    5  75657.000 ± 5323.225  ops/ms
```

### With MemorySegment (serialization and deserialization of a POJO object):
```
Benchmark                           Mode  Cnt      Score       Error   Units
BenchmarkRunner.testSerialization  thrpt    5  61702.604 ± 735.608  ops/ms
```

This branch passes all tests for the one.nio.serial component.