### PR TITLE
Generate valid bytecode for `NotSerial` record arguments, enable bytecode verification in tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,6 +127,9 @@ tasks {
             languageVersion.set(JavaLanguageVersion.of(testJdk))
         })
 
+
+        systemProperty("one.nio.gen.verify_bytecode", true)
+
         useJUnit()
         testLogging {
             debug {

--- a/src/main/java/one/nio/gen/BytecodeGenerator.java
+++ b/src/main/java/one/nio/gen/BytecodeGenerator.java
@@ -269,6 +269,26 @@ public class BytecodeGenerator extends ClassLoader implements BytecodeGeneratorM
         }
     }
 
+    public static void generateDefault(MethodVisitor mv, Field field) {
+        mv.visitInsn(defaultValueOpcode(Type.getType(field.getType())));
+    }
+
+    public static int defaultValueOpcode(Type type) {
+        switch (type.getSort()) {
+            case Type.OBJECT:
+            case Type.ARRAY:
+                return ACONST_NULL;
+            case Type.FLOAT:
+                return FCONST_0;
+            case Type.DOUBLE:
+                return DCONST_0;
+            case Type.LONG:
+                return LCONST_0;
+            default:
+                return ICONST_0;
+        }
+    }
+
     @Override
     public String getDumpPath() {
         return dumpPath;


### PR DESCRIPTION
  Fixes #107