### PR TITLE
SSL_sendfile: EAGAIN(EWOULDBLOCK) fix

### DIFF
--- a/src/main/java/one/nio/net/native/ssl.c
+++ b/src/main/java/one/nio/net/native/ssl.c
@@ -179,6 +179,14 @@ static int check_ssl_error(JNIEnv* env, SSL* ssl, int ret) {
                     throw_io_exception(env);
                     return 0;
                 }
+                // TBD: this workaround needs to be checked against the #23722 fix. Potentially, different issue.
+                if (errno == EWOULDBLOCK && reason == SSL_R_UNINITIALIZED) {
+                    return SSL_ERROR_WANT_WRITE;
+                }
+                if (errno > 0 && reason == SSL_R_UNINITIALIZED) {
+                    throw_io_exception_code(env, errno);
+                    return 0;
+                }
             }
             throw_ssl_exception(env);
             return 0;


### PR DESCRIPTION
When using SSL_sendfile under load, it was found that EWOULDBLOCK errorno (i.e. ) on a non-blocking socket was causing SSL_get_error() to return SSL_ERROR_SSL, but SSL_ERROR_WANT_WRITE was expected instead.

According to the documentation,
https://docs.openssl.org/3.2/man3/SSL_write/#notes
"If the underlying BIO is nonblocking the write functions will also return when the underlying BIO could not satisfy the needs of the function to continue the operation. In this case a call to SSL_get_error(3) with the return value of the write function will yield SSL_ERROR_WANT_READ or SSL_ERROR_WANT_WRITE."

Previously, the following issue (  https://github.com/openssl/openssl/issues/23722) was submitted against openssl library, and the current misbehaviour might also have been fixed in openssl 3.4.x version. 
So far there are no plans to upgrade openssl version, thhus, the workaround is proposed.