### PR TITLE
New SslOption::canUseSendfile

### DIFF
--- a/src/main/java/one/nio/net/NativeSslSocket.java
+++ b/src/main/java/one/nio/net/NativeSslSocket.java
@@ -88,6 +88,8 @@ class NativeSslSocket extends NativeSocket {
                 return sslSessionEarlyDataAccepted();
             case SslOption.SESSION_HANDSHAKE_DONE_ID:
                 return sslHandshakeDone();
+            case SslOption.CAN_USE_SENDFILE_ID:
+                return sslCanUseSendfile();
         }
         return null;
     }
@@ -134,6 +136,7 @@ class NativeSslSocket extends NativeSocket {
     private synchronized native int sslSessionTicket();
 
     private synchronized native String sslCurrentCipher();
+    private synchronized native boolean sslCanUseSendfile();
 
     static native long sslNew(int fd, long ctx, boolean serverMode) throws IOException;
     static native void sslFree(long ssl);

--- a/src/main/java/one/nio/net/SslOption.java
+++ b/src/main/java/one/nio/net/SslOption.java
@@ -27,6 +27,7 @@ public class SslOption<T> {
     static final int CURRENT_CIPHER_ID = 8;
     static final int SESSION_EARLYDATA_ACCEPTED_ID = 9;
     static final int SESSION_HANDSHAKE_DONE_ID = 10;
+    static final int CAN_USE_SENDFILE_ID = 11;
 
     public static final SslOption<byte[]> PEER_CERTIFICATE = new SslOption<>(PEER_CERTIFICATE_ID, byte[].class);
     public static final SslOption<Object[]> PEER_CERTIFICATE_CHAIN = new SslOption<>(PEER_CERTIFICATE_CHAIN_ID, Object[].class);
@@ -40,6 +41,7 @@ public class SslOption<T> {
     public static final SslOption<String> CURRENT_CIPHER = new SslOption<>(CURRENT_CIPHER_ID, String.class);
     public static final SslOption<Boolean> SESSION_EARLYDATA_ACCEPTED = new SslOption<>(SESSION_EARLYDATA_ACCEPTED_ID, Boolean.class);
     public static final SslOption<Boolean> SESSION_HANDSHAKE_DONE = new SslOption<>(SESSION_HANDSHAKE_DONE_ID, Boolean.class);
+    public static final SslOption<Boolean> CAN_USE_SENDFILE = new SslOption<>(CAN_USE_SENDFILE_ID, Boolean.class);
 
     final int id;
     final Class<T> type;

--- a/src/main/java/one/nio/net/native/ssl.c
+++ b/src/main/java/one/nio/net/native/ssl.c
@@ -1536,6 +1536,12 @@ Java_one_nio_net_NativeSslSocket_sslSessionTicket(JNIEnv* env, jobject self) {
     return ssl == NULL ? 0 : ((intptr_t)SSL_get_app_data(ssl) & SF_NEW_TICKET) >> 2;
 }
 
+JNIEXPORT jboolean JNICALL
+Java_one_nio_net_NativeSslSocket_sslCanUseSendfile(JNIEnv* env, jobject self) {
+    SSL* ssl = (SSL*)(intptr_t) (*env)->GetLongField(env, self, f_ssl);
+    return ssl != NULL && BIO_get_ktls_send(SSL_get_wbio(ssl)) ? JNI_TRUE : JNI_FALSE;
+}
+
 JNIEXPORT jstring JNICALL
 Java_one_nio_net_NativeSslSocket_sslCurrentCipher(JNIEnv* env, jobject self) {
     SSL* ssl = (SSL*)(intptr_t) (*env)->GetLongField(env, self, f_ssl);


### PR DESCRIPTION
Owing to various reasons  kernelTLS may not be initialised for a particular SSL session. In such cases, sslWrite()/sslRead() calls are seamlessly backed by SW TLS stack, which is impossible for sendfile(). The newly introduced option provides a way to check whether a session supports sendfile over TLS  prior to actual invocation.

A similar approach is used in the `openssl s_server` utility [here](https://github.com/openssl/openssl/blob/openssl-3.2.1/apps/s_server.c#L3478).