### PR TITLE
Don't pin carrier on timed JavaSocket.read() from a virtual thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 .idea
 *.iml
+.gradle

--- a/src/main/java/one/nio/net/JavaSocket.java
+++ b/src/main/java/one/nio/net/JavaSocket.java
@@ -17,6 +17,7 @@
 package one.nio.net;
 
 import one.nio.mem.DirectMemory;
+import one.nio.util.JavaFeatures;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -109,6 +110,15 @@ final class JavaSocket extends SelectableJavaSocket {
 
     @Override
     public final int read(byte[] data, int offset, int count, int flags) throws IOException {
+        if (flags == 0 && timeout > 0 && ch.isBlocking() && JavaFeatures.isVirtualThread()) {
+            // On a virtual thread, read via the blocking input stream (honors SO_TIMEOUT) so the
+            // JDK can unmount the carrier; checkTimeout()'s native Net.poll would pin it instead
+            int n = ch.socket().getInputStream().read(data, offset, count);
+            if (n < 0) {
+                throw new SocketClosedException();
+            }
+            return n;
+        }
         checkTimeout(POLL_READ, timeout);
         int result = ch.read(ByteBuffer.wrap(data, offset, count));
         if (result < 0) {

--- a/src/main/java/one/nio/util/JavaFeatures.java
+++ b/src/main/java/one/nio/util/JavaFeatures.java
@@ -23,6 +23,7 @@ import java.lang.invoke.MethodType;
 public class JavaFeatures {
     private static final MethodHandle onSpinWait = getOnSpinWait();
     private static final MethodHandle isRecord = getIsRecord();
+    private static final MethodHandle isVirtual = getIsVirtual();
 
     private static MethodHandle getOnSpinWait() {
         try {
@@ -37,6 +38,15 @@ public class JavaFeatures {
         try {
             return MethodHandles.publicLookup().findVirtual(
                     Class.class, "isRecord", MethodType.methodType(boolean.class));
+        } catch (ReflectiveOperationException e) {
+            return null;
+        }
+    }
+
+    private static MethodHandle getIsVirtual() {
+        try {
+            return MethodHandles.publicLookup().findVirtual(
+                    Thread.class, "isVirtual", MethodType.methodType(boolean.class));
         } catch (ReflectiveOperationException e) {
             return null;
         }
@@ -65,6 +75,22 @@ public class JavaFeatures {
         if (isRecord != null) {
             try {
                 return (boolean) isRecord.invokeExact(cls);
+            } catch (Throwable e) {
+                // Never happens
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Calls Thread.isVirtual() on the current thread since Java 21; returns false otherwise
+     *
+     * @return true if the current thread is a virtual thread. It is always false, if the version of the JVM Runtime is less than 21
+     */
+    public static boolean isVirtualThread() {
+        if (isVirtual != null) {
+            try {
+                return (boolean) isVirtual.invokeExact(Thread.currentThread());
             } catch (Throwable e) {
                 // Never happens
             }


### PR DESCRIPTION
# Make `JavaSocket.read` virtual-thread-friendly

## Problem

The read timeout in `JavaSocket.read` currently goes through
`SelectableJavaSocket.checkTimeout()` -> `sun.nio.ch.Net.poll`, which is a native call.

On a virtual thread, this native frame pins the carrier. While the thread is blocked in
`Net.poll`, the carrier cannot be unmounted. Because of that, an `HttpClient` driven from
virtual threads does not scale past the number of available carriers.

[JEP 491](https://openjdk.org/jeps/491) does not help in this case. It removes pinning for
some `synchronized` cases, but this path is blocked in a native frame, so the pinning remains
on JDK 24+.

## Solution

For virtual threads, route timed `byte[]` reads through the `SO_TIMEOUT` input stream path:

`getInputStream()` -> `NioSocketImpl`

The timeout is still honored, but the carrier is unmounted instead of being pinned. Platform
threads keep using the existing path, so their behavior does not change.

```java
public int read(byte[] data, int offset, int count, int flags) {
    if (flags == 0 && timeout > 0 && ch.isBlocking() && JavaFeatures.isVirtualThread()) {
        // Use the SO_TIMEOUT stream path instead of the pinning Net.poll path.
        int n = ch.socket().getInputStream().read(data, offset, count);
        ...
    }

    checkTimeout(POLL_READ, timeout);            // existing path
    return ch.read(ByteBuffer.wrap(data, offset, count));
}
```

This path is intentionally limited to cases where the stream read preserves the same semantics:

* `isVirtualThread()` - only virtual threads have the carrier-pinning problem here;
* `timeout > 0` - without a timeout, blocking `ch.read` already unmounts;
* `ch.isBlocking()` - `InputStream` only works in blocking mode;
* `flags == 0` - `InputStream` cannot pass recv flags.

`isVirtualThread()` uses reflective `Thread.isVirtual()` and returns `false` on JDK < 21.

## Before / after

Test setup:

* Server: one-nio `HttpServer`, endpoint `GET /api/test` with `Thread.sleep(100)` to simulate
  a ~100 ms downstream call. 
  `selectors=256`: because one-nio runs HTTP handlers inline on
  selector threads and the server should not be the bottleneck.
* Client: one-nio `HttpClient` driven from 200 virtual threads.
  `parallelism` / carriers = 14, `clientMaxPoolSize=204`, `timeout=10000` ms.

#### RPS before the fix

```
Profiling started
CLIENT  JDK=25.0.3 | pid=1 | sockets=JAVA (NativeLibrary.IS_SUPPORTED=true, force.java.socket=true)
        url=http://server:8080/api/test | tasks=200 | carriers=14 | poolSize=204 | timeout=10000ms | load.seconds=60

SUSTAINED load: 200 virtual threads for 60s - attach the profiler now.
  t= 2s  ok=227   rps=114  errors=0
  t= 4s  ok=482   rps=120  errors=0
  ...
  ...
  t=58s  ok=7764  rps=134  errors=0
  t=60s  ok=8048  rps=134  errors=0

DONE: ok=8216 errors=0 in 61146ms -> 134 rps (concurrency=200)
```

#### RPS after the fix

```
Profiling started
CLIENT  JDK=25.0.3 | pid=1 | sockets=JAVA (NativeLibrary.IS_SUPPORTED=true, force.java.socket=true)
        url=http://server:8080/api/test | tasks=200 | carriers=14 | poolSize=204 | timeout=10000ms | load.seconds=60

SUSTAINED load: 200 virtual threads for 60s - attach the profiler now.
  t= 2s  ok=1537   rps=768   errors=0
  t= 4s  ok=3349   rps=836   errors=0
  ...
  ...
  t=58s  ok=92036  rps=1584  errors=0
  t=60s  ok=95317  rps=1586  errors=0

DONE: ok=95321 errors=0 in 60213ms -> 1583 rps (concurrency=200)
```

| version | sockets | RPS                                            |
| ------- | ------- | ---------------------------------------------- |
| before  | java    | 134 - pinned in `Net.poll`, capped at carriers |
| after   | java    | 1583 - unmounted / parked                      |

### Wall-clock flame graphs

Before:

`JavaSocket.read` -> `checkTimeout` -> `Net.poll` takes ~37% of wall-clock time.
The carrier threads are stuck in the native poll.

<img width="3420" height="1208" alt="image" src="https://github.com/user-attachments/assets/b4090c18-832a-459c-bba3-c66616815320" />

After:

`Net.poll` is ~0%. The same waiting time moves to `Unsafe.park`, which is ~35%.
This means the virtual threads are parked and the carriers can be reused.

<img width="3424" height="1206" alt="image" src="https://github.com/user-attachments/assets/12a932c0-d81f-4bd8-a7e2-b0f10f6424f8" />