### PR TITLE
SO_REUSEPORT support for JavaDatagramSocket

### DIFF
--- a/src/main/java/one/nio/net/JavaDatagramSocket.java
+++ b/src/main/java/one/nio/net/JavaDatagramSocket.java
@@ -23,6 +23,7 @@ import java.io.RandomAccessFile;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
+import java.net.SocketOption;
 import java.net.StandardSocketOptions;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
@@ -92,6 +93,11 @@ final class JavaDatagramSocket extends SelectableJavaSocket {
     @Override
     public final int send(ByteBuffer src, int flags, InetAddress address, int port) throws IOException {
         return ch.send(src, new InetSocketAddress(address, port));
+    }
+
+    @Override
+    public final int send(ByteBuffer src, int flags, InetSocketAddress address) throws IOException {
+        return ch.send(src, address);
     }
 
     @Override
@@ -229,6 +235,9 @@ final class JavaDatagramSocket extends SelectableJavaSocket {
     public final void setReuseAddr(boolean reuseAddr, boolean reusePort) {
         try {
             ch.setOption(StandardSocketOptions.SO_REUSEADDR, reuseAddr);
+            if (isReusePortSupported()) {
+                ch.setOption(SO_REUSEPORT_COMPAT, reusePort);
+            }
         } catch (IOException e) {
             // Ignore
         }
@@ -245,7 +254,13 @@ final class JavaDatagramSocket extends SelectableJavaSocket {
 
     @Override
     public boolean getReusePort() {
-        return false;
+        try {
+            return isReusePortSupported()
+                    ? ch.getOption(SO_REUSEPORT_COMPAT)
+                    : false;
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     @Override
@@ -353,5 +368,9 @@ final class JavaDatagramSocket extends SelectableJavaSocket {
     @Override
     public SelectableChannel getSelectableChannel() {
         return ch;
+    }
+
+    private boolean isReusePortSupported() {
+        return SO_REUSEPORT_COMPAT != null ? ch.supportedOptions().contains(SO_REUSEPORT_COMPAT) : false;
     }
 }

--- a/src/main/java/one/nio/net/JavaServerSocket.java
+++ b/src/main/java/one/nio/net/JavaServerSocket.java
@@ -32,8 +32,6 @@ import java.nio.channels.SocketChannel;
 import one.nio.util.JavaInternals;
 
 final class JavaServerSocket extends SelectableJavaSocket {
-    private static final SocketOption<Boolean> SO_REUSEPORT_COMPAT = findReusePortOption();
-
     final ServerSocketChannel ch;
 
     JavaServerSocket() throws IOException {
@@ -92,6 +90,11 @@ final class JavaServerSocket extends SelectableJavaSocket {
 
     @Override
     public final int send(ByteBuffer src, int flags, InetAddress address, int port) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final int send(ByteBuffer src, int flags, InetSocketAddress address) throws IOException {
         throw new UnsupportedOperationException();
     }
 
@@ -338,16 +341,5 @@ final class JavaServerSocket extends SelectableJavaSocket {
     @Override
     public SelectableChannel getSelectableChannel() {
         return ch;
-    }
-
-    private static SocketOption<Boolean> findReusePortOption() {
-        try {
-            Field reusePortField = JavaInternals.findField(StandardSocketOptions.class, "SO_REUSEPORT");
-            if (reusePortField != null) {
-                return (SocketOption<Boolean>) reusePortField.get(null);
-            }
-        } catch (Throwable ignored) {
-        }
-        return null;
     }
 }

--- a/src/main/java/one/nio/net/JavaSocket.java
+++ b/src/main/java/one/nio/net/JavaSocket.java
@@ -99,6 +99,11 @@ final class JavaSocket extends SelectableJavaSocket {
     }
 
     @Override
+    public final int send(ByteBuffer src, int flags, InetSocketAddress address) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public final int readRaw(long buf, int count, int flags) throws IOException {
         checkTimeout(POLL_READ, timeout);
         int result = ch.read(DirectMemory.wrap(buf, count));

--- a/src/main/java/one/nio/net/JavaSslClientSocket.java
+++ b/src/main/java/one/nio/net/JavaSslClientSocket.java
@@ -104,6 +104,11 @@ public final class JavaSslClientSocket extends Socket {
     }
 
     @Override
+    public int send(ByteBuffer src, int flags, InetSocketAddress address) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public int readRaw(long buf, int count, int flags) throws IOException {
         return inCh.read(DirectMemory.wrap(buf, count));
     }

--- a/src/main/java/one/nio/net/NativeSocket.java
+++ b/src/main/java/one/nio/net/NativeSocket.java
@@ -121,6 +121,14 @@ class NativeSocket extends Socket {
     }
 
     @Override
+    public int send(ByteBuffer src, int flags, InetSocketAddress address) throws IOException {
+        if (address.isUnresolved()) {
+            throw new IOException("Address " + address + " is unresolved");
+        }
+        return sendTo(src, flags, address.getAddress().getAddress(), address.getPort());
+    }
+
+    @Override
     public int send(ByteBuffer data, int flags, String host, int port) throws IOException {
         return sendTo(data, flags, toNativeAddr(host, port), port);
     }

--- a/src/main/java/one/nio/net/SelectableJavaSocket.java
+++ b/src/main/java/one/nio/net/SelectableJavaSocket.java
@@ -27,7 +27,9 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.net.SocketOption;
 import java.net.SocketTimeoutException;
+import java.net.StandardSocketOptions;
 import java.nio.channels.SelectableChannel;
 
 import static one.nio.util.JavaInternals.unsafe;
@@ -43,6 +45,7 @@ public abstract class SelectableJavaSocket extends Socket {
 
     static final int POLL_READ = getFieldValue("sun.nio.ch.Net", "POLLIN");
     static final int POLL_WRITE = getFieldValue("sun.nio.ch.Net", "POLLOUT");
+    protected static final SocketOption<Boolean> SO_REUSEPORT_COMPAT = findReusePortOption();
 
     private static MethodHandle getMethodHandle(String cls, String name, Class<?>... params) {
         try {
@@ -89,4 +92,16 @@ public abstract class SelectableJavaSocket extends Socket {
     }
 
     public abstract SelectableChannel getSelectableChannel();
+
+    private static SocketOption<Boolean> findReusePortOption() {
+        try {
+            Field reusePortField = JavaInternals.findField(StandardSocketOptions.class, "SO_REUSEPORT");
+            if (reusePortField != null) {
+                return (SocketOption<Boolean>) reusePortField.get(null);
+            }
+        } catch (Throwable ignored) {
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/one/nio/net/Socket.java
+++ b/src/main/java/one/nio/net/Socket.java
@@ -117,6 +117,7 @@ public abstract class Socket implements ByteChannel {
     public abstract int write(byte[] data, int offset, int count, int flags) throws IOException;
     public abstract void writeFully(byte[] data, int offset, int count) throws IOException;
     public abstract int send(ByteBuffer src, int flags, InetAddress address, int port) throws IOException;
+    public abstract int send(ByteBuffer src, int flags, InetSocketAddress address) throws IOException;
     public abstract int readRaw(long buf, int count, int flags) throws IOException;
     public abstract int read(byte[] data, int offset, int count, int flags) throws IOException;
     public abstract void readFully(byte[] data, int offset, int count) throws IOException;


### PR DESCRIPTION
Support for SO_REUSEPORT has been added to JavaDatagramSocket.

Socket interface has been extended with the method `public final int send(ByteBuffer src, int flags, InetSocketAddress address)` to reduce the number of redundant allocations in JavaDatagramSocket.