### PR TITLE
Make socket pollable

### DIFF
--- a/src/main/java/one/nio/net/JavaSslClientSocket.java
+++ b/src/main/java/one/nio/net/JavaSslClientSocket.java
@@ -354,12 +354,8 @@ public final class JavaSslClientSocket extends Socket {
     }
 
     @Override
-    public boolean poll() {
-        try {
-            return inputStream.available() > 0;
-        } catch (IOException e) {
-            return false;
-        }
+    public boolean poll() throws IOException {
+        return inputStream.available() > 0;
     }
 
     @Override

--- a/src/main/java/one/nio/net/JavaSslClientSocket.java
+++ b/src/main/java/one/nio/net/JavaSslClientSocket.java
@@ -354,6 +354,20 @@ public final class JavaSslClientSocket extends Socket {
     }
 
     @Override
+    public boolean poll() {
+        try {
+            return inputStream.available() > 0;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean pollable() {
+        return true;
+    }
+
+    @Override
     public void listen(int backlog) throws IOException {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/one/nio/net/NativeSocket.java
+++ b/src/main/java/one/nio/net/NativeSocket.java
@@ -67,7 +67,7 @@ class NativeSocket extends Socket {
     public final native InetSocketAddress getRemoteAddress();
 
     @Override
-    public final native boolean poll();
+    public final native boolean poll() throws IOException;
 
     @Override
     public boolean pollable() {

--- a/src/main/java/one/nio/net/NativeSocket.java
+++ b/src/main/java/one/nio/net/NativeSocket.java
@@ -67,6 +67,14 @@ class NativeSocket extends Socket {
     public final native InetSocketAddress getRemoteAddress();
 
     @Override
+    public final native boolean poll();
+
+    @Override
+    public boolean pollable() {
+        return true;
+    }
+
+    @Override
     public Socket sslWrap(SslContext context) throws IOException {
         return new NativeSslSocket(fd, (NativeSslContext) context, false);
     }

--- a/src/main/java/one/nio/net/SelectableJavaSocket.java
+++ b/src/main/java/one/nio/net/SelectableJavaSocket.java
@@ -92,16 +92,18 @@ public abstract class SelectableJavaSocket extends Socket {
     }
 
     @Override
-    public boolean poll() {
+    public boolean poll() throws IOException {
         if (poll == null || getFD == null) {
-            return false;
+            throw new IllegalStateException("Failed to access sun.nio.ch API");
         }
         try {
             FileDescriptor fd = (FileDescriptor) getFD.invoke(getSelectableChannel());
             int result = (int) poll.invokeExact(fd, POLL_READ, 0L);
             return result > 0;
+        } catch (IOException e) {
+            throw e;
         } catch (Throwable e) {
-            return false;
+            throw new IOException(e);
         }
     }
 

--- a/src/main/java/one/nio/net/SelectableJavaSocket.java
+++ b/src/main/java/one/nio/net/SelectableJavaSocket.java
@@ -91,6 +91,25 @@ public abstract class SelectableJavaSocket extends Socket {
         throw new SocketTimeoutException();
     }
 
+    @Override
+    public boolean poll() {
+        if (poll == null || getFD == null) {
+            return false;
+        }
+        try {
+            FileDescriptor fd = (FileDescriptor) getFD.invoke(getSelectableChannel());
+            int result = (int) poll.invokeExact(fd, POLL_READ, 0L);
+            return result > 0;
+        } catch (Throwable e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean pollable() {
+        return true;
+    }
+
     public abstract SelectableChannel getSelectableChannel();
 
     private static SocketOption<Boolean> findReusePortOption() {

--- a/src/main/java/one/nio/net/Socket.java
+++ b/src/main/java/one/nio/net/Socket.java
@@ -167,6 +167,14 @@ public abstract class Socket implements ByteChannel {
         return s;
     }
 
+    public boolean poll() {
+        return true;
+    }
+
+    public boolean pollable() {
+        return false;
+    }
+
     public void connect(String host, int port) throws IOException {
         connect(InetAddress.getByName(host), port);
     }

--- a/src/main/java/one/nio/net/Socket.java
+++ b/src/main/java/one/nio/net/Socket.java
@@ -167,8 +167,8 @@ public abstract class Socket implements ByteChannel {
         return s;
     }
 
-    public boolean poll() {
-        return true;
+    public boolean poll() throws IOException {
+        throw new UnsupportedOperationException();
     }
 
     public boolean pollable() {

--- a/src/main/java/one/nio/net/native/socket.c
+++ b/src/main/java/one/nio/net/native/socket.c
@@ -16,6 +16,7 @@
 
 #include <sys/time.h>
 #include <sys/resource.h>
+#include <poll.h>
 #include <sys/sendfile.h>
 #include <sys/socket.h>
 #include <sys/syscall.h>
@@ -601,6 +602,25 @@ Java_one_nio_net_NativeSocket_recvFrom1(JNIEnv* env, jobject self, jlong buffer,
         } while (errno == EINTR);
     }
     return 0;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_one_nio_net_NativeSocket_poll(JNIEnv* env, jobject self) {
+    int fd = (*env)->GetIntField(env, self, f_fd);
+    if (fd == -1) {
+        throw_socket_closed(env);
+        return JNI_FALSE;
+    }
+
+    struct pollfd pfd;
+    pfd.fd = fd;
+    pfd.events = POLLIN;
+    int result = poll(&pfd, 1, 0);
+    if (result == -1) {
+        throw_io_exception(env);
+        return JNI_FALSE;
+    }
+    return (result > 0) ? JNI_TRUE : JNI_FALSE;
 }
 
 JNIEXPORT jint JNICALL


### PR DESCRIPTION
Reason:
The read method of the NativeSocket class blocks the entire socket until at least one byte is read. I need to be able to write and read to the socket independently, so I added the poll method. Now I can check if there is any data in the socket and only read if there is, otherwise I don't block the socket indefinitely.